### PR TITLE
Phase 3 cleanup of #28: bake auth.ehds.mabu.red into deploy + docs

### DIFF
--- a/bruno/MVHDv2/environments/Azure-Dev.bru
+++ b/bruno/MVHDv2/environments/Azure-Dev.bru
@@ -1,7 +1,7 @@
 vars {
   baseUrl: https://ehds.mabu.red
   proxyUrl: https://ehds.mabu.red
-  ~keycloakUrl: https://auth.ehds.mabu.red
+  keycloakUrl: https://auth.ehds.mabu.red
   participantId: alpha-clinic
   patientId: P1
   studyId: study-001

--- a/docs/ADRs/ADR-025-keycloak-custom-domain.md
+++ b/docs/ADRs/ADR-025-keycloak-custom-domain.md
@@ -1,0 +1,90 @@
+# ADR-025: Keycloak Custom Domain (`auth.ehds.mabu.red`)
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Relates to:** [ADR-012](ADR-012-azure-container-apps.md), [ADR-014](ADR-014-weekly-demo-reset.md)
+**Tracking:** Issue [#28](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/28) (closed)
+
+## Context
+
+Until 2026-05-10 the OIDC sign-in flow on `https://ehds.mabu.red/auth/signin` redirected the browser to the long ACA-internal Keycloak hostname:
+
+```
+https://mvhd-keycloak.happysand-37f82e30.westeurope.azurecontainerapps.io/realms/edcv/protocol/openid-connect/auth?...
+```
+
+Mechanically correct OIDC, but a poor trust signal during regulator-facing demos. A regulator looking at the URL bar sees an unfamiliar `azurecontainerapps.io` host and questions whether they're still on the right system. The sign-in handshake briefly leaving the application domain is unavoidable in OIDC, but it can stay within the same DNS family.
+
+## Decision
+
+Bind the custom subdomain `auth.ehds.mabu.red` to the `mvhd-keycloak` Azure Container Apps app and reconfigure the OIDC chain so every browser-visible URL during sign-in stays within `*.ehds.mabu.red`.
+
+The OIDC dance now reads:
+
+```
+ehds.mabu.red/auth/signin
+  → auth.ehds.mabu.red/realms/edcv/protocol/openid-connect/auth?...
+  → ehds.mabu.red/api/auth/callback/keycloak
+```
+
+`KEYCLOAK_INTERNAL_URL` stays on the ACA-internal FQDN (`mvhd-keycloak.internal.<env>.azurecontainerapps.io`) for the server-to-server token exchange path: from inside the UI container, `localhost` resolves to the container itself, and the public `auth.ehds.mabu.red` would route the traffic back out through the ingress unnecessarily. This split is consistent with CLAUDE.md gotcha #5.
+
+## Implementation
+
+The full sequence is automated in `.github/workflows/keycloak-custom-domain.yml`. Two modes:
+
+- `dns_check_only` resolves the ACA env's `customDomainVerificationId`, prints the two DNS records the maintainer must add at iwantmyname.com (the registrar / DNS provider for `mabu.red`), and probes live DNS to confirm both match.
+- `cutover` is gated behind a hard DNS-readiness check, then runs `az containerapp hostname add/bind --validation-method CNAME` (managed cert, ~5–8 min), updates Keycloak env (`KC_HOSTNAME`, `KC_PROXY_HEADERS=xforwarded`, `KC_HOSTNAME_STRICT_BACKCHANNEL=false`), merges `https://auth.ehds.mabu.red` into the `health-dataspace-ui` realm client's `webOrigins` via the Admin API, updates UI env vars (`KEYCLOAK_PUBLIC_URL`, `KEYCLOAK_ISSUER`, `NEXT_PUBLIC_KEYCLOAK_URL`), and verifies `https://auth.ehds.mabu.red/realms/edcv/.well-known/openid-configuration` returns 200.
+
+The deploy scripts under `scripts/azure/` honour a new `KEYCLOAK_PUBLIC_HOSTNAME` env var (default: ACA FQDN; set to `auth.ehds.mabu.red` for production redeploys). Fresh deploys without the override still produce a working stack on the ACA FQDN; the custom-domain bind is then applied via the cutover workflow.
+
+A Playwright regression test (`ui/__tests__/e2e/17-role-navigation-e2e.spec.ts → "sign-in flow stays within *.ehds.mabu.red domain (issue #28)"`) hooks `page.framenavigated()` during a real Keycloak login round-trip and asserts every host is in the `ehds.mabu.red` eTLD+1 family. It additionally asserts the `auth.*` subdomain WAS in the chain so the test fails closed if a future shortcut bypasses the IdP entirely.
+
+## Consequences
+
+### Positive
+
+- **Demo trust**. During regulator and ministry sessions, the browser URL bar consistently shows `*.ehds.mabu.red` throughout the sign-in flow.
+- **Documented decision trail**. The Phase 2 workflow is reusable for any future custom-domain work; the ADR records the exact `az containerapp` calls and env-var names.
+- **Reversible**. The cutover steps are individually reversible without a clean rebuild.
+- **Regression-protected**. The new Playwright test fails on any future change that re-introduces the long ACA-FQDN.
+
+### Trade-offs
+
+- **One-time silent sign-out** at the moment of cutover when `KEYCLOAK_ISSUER` flipped — anyone with an in-flight session got logged out. One-time event.
+- **Two DNS records to maintain at iwantmyname.com**: a TXT (Azure verification) and a CNAME. The TXT is tied to the ACA env's `customDomainVerificationId`; if the env is rebuilt, the TXT must be refreshed.
+- **Managed cert renewal** is automatic but ACA owns the cert lifecycle. Cert revocation requires an operator step.
+
+### Rollback
+
+If the custom domain needs to be retired:
+
+```bash
+# 1. Revert UI env vars to the ACA FQDN
+az containerapp update -n mvhd-ui -g rg-mvhd-dev --set-env-vars \
+    "KEYCLOAK_PUBLIC_URL=https://mvhd-keycloak.happysand-37f82e30.westeurope.azurecontainerapps.io/realms/edcv" \
+    "KEYCLOAK_ISSUER=https://mvhd-keycloak.happysand-37f82e30.westeurope.azurecontainerapps.io/realms/edcv" \
+    "NEXT_PUBLIC_KEYCLOAK_URL=https://mvhd-keycloak.happysand-37f82e30.westeurope.azurecontainerapps.io"
+
+# 2. Revert Keycloak env vars
+az containerapp update -n mvhd-keycloak -g rg-mvhd-dev --remove-env-vars \
+    KC_HOSTNAME KC_HOSTNAME_STRICT_BACKCHANNEL KC_PROXY_HEADERS
+
+# 3. Remove the custom domain binding from Keycloak
+az containerapp hostname remove -n mvhd-keycloak -g rg-mvhd-dev \
+    --hostname auth.ehds.mabu.red
+
+# 4. Delete the DNS records at iwantmyname.com
+#    https://iwantmyname.com/dashboard/domains/mabu.red/dns
+#    Delete: TXT asuid.auth.ehds, CNAME auth.ehds
+```
+
+After step 1 every signed-in user is logged out one final time when the issuer claim no longer matches.
+
+## References
+
+- Issue [#28](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/28) — sign-in stays on `*.ehds.mabu.red`
+- `.github/workflows/keycloak-custom-domain.yml` — Phase 2 cutover automation
+- `ui/__tests__/e2e/17-role-navigation-e2e.spec.ts` — regression test
+- ADR-012 — original ACA topology
+- ADR-014 — weekly demo reset (the realm-import fix that surfaced this work)

--- a/docs/planning-health-dataspace-v2.md
+++ b/docs/planning-health-dataspace-v2.md
@@ -3827,6 +3827,7 @@ New spec `ui/__tests__/e2e/journeys/32-federated-nlq.spec.ts`:
 | [022](ADRs/ADR-022-edc-connector-cost-vs-function.md)        | EDC Connector: Function vs Cost (Issue #25)    | 2026-05-03 | Superseded |
 | [023](ADRs/ADR-023-reinstate-off-hours-scaledown.md)         | Reinstate Off-Hours ACA Scale-Down             | 2026-05-01 | Accepted   |
 | [024](ADRs/ADR-024-full-edc-provisioning-per-participant.md) | Full EDC Provisioning per Participant on Azure | 2026-05-04 | Accepted   |
+| [025](ADRs/ADR-025-keycloak-custom-domain.md)                | Keycloak Custom Domain (auth.ehds.mabu.red)    | 2026-05-10 | Accepted   |
 
 > **Note:** The full text of ADR-1 through ADR-9 has been moved into the standalone ADR documents linked in the table above. Click any row to read the full context, decision, and consequences.
 

--- a/scripts/azure/03-identity.sh
+++ b/scripts/azure/03-identity.sh
@@ -34,8 +34,10 @@ az containerapp create \
     "KC_DB_URL=${PG_JDBC}" \
     "KC_DB_USERNAME=${PG_ADMIN}" \
     "KC_DB_PASSWORD=${PG_PASSWORD}" \
+    "KC_HOSTNAME=${KEYCLOAK_PUBLIC_HOSTNAME}" \
     "KC_HOSTNAME_STRICT=false" \
-    "KC_PROXY=edge" \
+    "KC_HOSTNAME_STRICT_BACKCHANNEL=false" \
+    "KC_PROXY_HEADERS=xforwarded" \
     "KEYCLOAK_ADMIN=${KC_ADMIN_USER}" \
     "KEYCLOAK_ADMIN_PASSWORD=${KC_ADMIN_PASSWORD}" \
   -o none

--- a/scripts/azure/env.sh
+++ b/scripts/azure/env.sh
@@ -113,7 +113,14 @@ export NEO4J_HTTP_URL="https://${NEO4J_APP}.internal.${domain}"
 export NEO4J_PROXY_URL="https://${NEO4J_PROXY_APP}.internal.${domain}"
 export VAULT_URL="https://${VAULT_APP}.internal.${domain}"
 export KEYCLOAK_INTERNAL_URL="https://${KEYCLOAK_APP}.internal.${domain}"
-export KEYCLOAK_PUBLIC_URL="https://${KEYCLOAK_APP}.${domain}"
+# KEYCLOAK_PUBLIC_URL: external-facing Keycloak URL. After issue #28 Phase 2,
+# the canonical value is https://auth.ehds.mabu.red — set
+# KEYCLOAK_PUBLIC_HOSTNAME=auth.ehds.mabu.red in your shell before sourcing
+# env.sh to pick it up. Default falls back to the long ACA FQDN so fresh
+# deploys work even when DNS hasn't been bound yet (run the
+# keycloak-custom-domain workflow afterwards to flip to the custom domain).
+export KEYCLOAK_PUBLIC_HOSTNAME="\${KEYCLOAK_PUBLIC_HOSTNAME:-${KEYCLOAK_APP}.${domain}}"
+export KEYCLOAK_PUBLIC_URL="https://\${KEYCLOAK_PUBLIC_HOSTNAME}"
 export UI_PUBLIC_URL="https://${UI_APP}.${domain}"
 export CONTROLPLANE_URL="https://${CONTROLPLANE_APP}.internal.${domain}"
 export NATS_URL="nats://${NATS_APP}.internal.${domain}:4222"

--- a/ui/__tests__/e2e/17-role-navigation-e2e.spec.ts
+++ b/ui/__tests__/e2e/17-role-navigation-e2e.spec.ts
@@ -615,13 +615,13 @@ test.describe("Login flow — Keycloak integration", () => {
     );
   });
 
-  // Issue #28: sign-in flow must visually stay within *.ehds.mabu.red.
-  // When the Keycloak custom domain (auth.ehds.mabu.red) is bound, every
-  // intermediate URL during the OIDC code-flow round-trip should be in
-  // the ehds.mabu.red eTLD+1 family. Until Phase 2 of #28 lands, the IdP
-  // hostname is still the long mvhd-keycloak….azurecontainerapps.io and
-  // this test would fail; gate on KEYCLOAK_PUBLIC_URL so the test
-  // becomes the regression check that confirms Phase 2 is in effect.
+  // Issue #28 (closed 2026-05-10): sign-in flow stays within
+  // *.ehds.mabu.red. The Keycloak custom domain auth.ehds.mabu.red is
+  // bound; every intermediate URL during the OIDC code-flow round-trip
+  // is in the ehds.mabu.red eTLD+1 family. The KEYCLOAK_PUBLIC_URL
+  // gate keeps the test runnable in environments that haven't deployed
+  // the custom-domain change yet (test skips cleanly there) — drop the
+  // gate when the ACA-FQDN fallback path is removed entirely.
   test("sign-in flow stays within *.ehds.mabu.red domain (issue #28)", async ({
     page,
   }) => {


### PR DESCRIPTION
Phase 3 follow-up to closed issue [#28](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/28). Brings the deploy scripts and docs into alignment with the live state (cutover succeeded on 2026-05-10).

## What this PR does

| File | Change |
|---|---|
| `scripts/azure/env.sh` | New `KEYCLOAK_PUBLIC_HOSTNAME` override (default: ACA FQDN; set to `auth.ehds.mabu.red` for production). `KEYCLOAK_PUBLIC_URL` now derives from it. |
| `scripts/azure/03-identity.sh` | Adds `KC_HOSTNAME=${KEYCLOAK_PUBLIC_HOSTNAME}`, replaces deprecated `KC_PROXY=edge` with `KC_PROXY_HEADERS=xforwarded` (Keycloak 26+), adds `KC_HOSTNAME_STRICT_BACKCHANNEL=false`. |
| `bruno/MVHDv2/environments/Azure-Dev.bru` | Drops the `~` disabled-prefix on `keycloakUrl` so the var activates. |
| `ui/__tests__/e2e/17-role-navigation-e2e.spec.ts` | Updates the comment block on the regression test to reflect post-cutover state. Logic unchanged. |
| `docs/ADRs/ADR-025-keycloak-custom-domain.md` | New ADR with decision, implementation summary, and exact 4-step rollback procedure. |
| `docs/planning-health-dataspace-v2.md` | ADR index row for ADR-025. |

## What this PR does NOT do

- No live infra changes — the cutover already happened.
- No new tests — the existing regression test (`sign-in flow stays within *.ehds.mabu.red domain`) already gates this.

## Risk

Low. A redeploy from this branch behaves identically to today's live state when `KEYCLOAK_PUBLIC_HOSTNAME=auth.ehds.mabu.red` is exported beforehand. Without the override, a fresh deploy lands on the ACA FQDN exactly as today's deploy would, then the maintainer runs `gh workflow run keycloak-custom-domain.yml -f mode=cutover` to flip.

## Acceptance

- [x] Deploy scripts honour the new override variable
- [x] Keycloak env vars match what's already on the live container app (`KC_HOSTNAME=auth.ehds.mabu.red`, `KC_PROXY_HEADERS=xforwarded`)
- [x] ADR-025 records decision + rollback
- [x] Bruno var active for collection scripts to reference