### PR TITLE
chore(deps): pin fast-uri ^3.1.2 to clear HIGH CVE on every PR

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8218,9 +8218,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -12148,6 +12148,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,8 @@
     "test:e2e:ui": "playwright test --config playwright.config.ts --ui"
   },
   "overrides": {
-    "neverpanic": "^0.0.7"
+    "neverpanic": "^0.0.7",
+    "fast-uri": "^3.1.2"
   },
   "dependencies": {
     "@scalar/api-reference-react": "^0.9.0",


### PR DESCRIPTION
The Dependency Audit job has been failing on every PR for the last week because fast-uri@3.1.0 (transitive via Scalar → ajv) carries two HIGH advisories:

- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters

Both fixed in fast-uri@3.1.2. Pinning via `npm overrides` so we don't have to wait for Scalar's ajv bump.

## Diff

```jsonc
"overrides": {
    "neverpanic": "^0.0.7",
+   "fast-uri": "^3.1.2"
}
```

Plus the regenerated `ui/package-lock.json`.

## Verification

| Check | Result |
|---|---|
| `npm install` | clean, lockfile regenerated |
| `npm ls fast-uri` | `fast-uri@3.1.2` deduped at every depth |
| `npm audit --audit-level=high` | no HIGH advisories (returns 0) |
| `npx tsc --noEmit -p tsconfig.build.json` | clean |
| `vitest admin-policies` smoke | 9/9 pass |

## Out of scope

The 4 remaining **moderate** advisories (postcss XSS in CSS Stringify, uuid v3/v5/v6 buffer bounds, …) aren't gated by the CI audit level (`--audit-level=high`). The postcss fix would force a Next.js downgrade with cascading breakages — leaving for a separate, larger upgrade PR.