### PR TITLE
feat(azure): seed 5 EHDS ParticipantContexts on Azure (issue #25)

### DIFF
--- a/.github/workflows/edc-seed-participants.yml
+++ b/.github/workflows/edc-seed-participants.yml
@@ -1,0 +1,169 @@
+name: EDC Seed Participants (issue #25)
+
+# Seeds 5 EHDS ParticipantContexts into the live IdentityHub on Azure so
+# the /compliance/tck page DSP-2.x and DCP-2.x rows flip from skipped to
+# green. Mirrors jad/seed-all.sh phases 2-3 (participant + key-pair) but
+# against ACA-internal IH endpoints.
+#
+# Architecture: IH is internal-ingress only, so the seed runs as a
+# one-shot ACA Job inside the same env. The job inlines the bash from
+# scripts/azure/05-edc-seed.sh (the canonical source) — keep them in
+# sync if you change either.
+#
+# Manual trigger only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      keycloak_url:
+        description: "Public Keycloak URL"
+        type: string
+        default: "https://auth.ehds.mabu.red"
+      flip_tck_optional:
+        description: "Also flip TCK_INFRA_OPTIONAL=false on the proxy after seeding"
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: "azure-edc-seed"
+  cancel-in-progress: false
+
+env:
+  RESOURCE_GROUP: rg-mvhd-dev
+  ACA_ENV: mvhd-env
+  IH_INTERNAL_URL: http://mvhd-identityhub:7082/api/identity
+  KC_REALM: edcv
+  # The proxy's TCK probe authenticates as this client. Seeding uses the
+  # same identity so the participants end up with consistent ownership.
+  KC_CLIENT_ID: admin
+  KC_CLIENT_SECRET: edc-v-admin-secret
+
+jobs:
+  seed:
+    name: Seed 5 EHDS participants
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure IH is scaled up
+        run: |
+          MIN=$(az containerapp show -n mvhd-identityhub -g $RESOURCE_GROUP \
+            --query "properties.template.scale.minReplicas" -o tsv)
+          if [ "$MIN" != "1" ]; then
+            echo "Scaling mvhd-identityhub to min=1 (was $MIN)"
+            az containerapp update -n mvhd-identityhub -g $RESOURCE_GROUP \
+              --min-replicas 1 --max-replicas 1 -o none
+            echo "Waiting 60s for IH to be ready..."
+            sleep 60
+          else
+            echo "IH already at min=1"
+          fi
+
+      - name: Run seed as one-shot ACA Job
+        run: |
+          ENV_ID=$(az containerapp env show -n "$ACA_ENV" -g "$RESOURCE_GROUP" \
+                     --query "id" -o tsv)
+          # Read the canonical script and inline it into the job's args, so
+          # the job's container has no image-build dependency. We use a
+          # plain alpine + curl + python3 image that's already on the
+          # mirror used elsewhere.
+          SCRIPT_B64=$(base64 < scripts/azure/05-edc-seed.sh | tr -d '\n')
+
+          cat > /tmp/seed-job.yaml <<EOF
+          type: Microsoft.App/jobs
+          properties:
+            configuration:
+              triggerType: Manual
+              replicaTimeout: 300
+              replicaRetryLimit: 0
+              manualTriggerConfig:
+                replicaCompletionCount: 1
+                parallelism: 1
+            environmentId: ${ENV_ID}
+            template:
+              containers:
+                - name: seed
+                  image: alpine:3.20
+                  resources: { cpu: 0.25, memory: 0.5Gi }
+                  env:
+                    - { name: IH,               value: "${IH_INTERNAL_URL}" }
+                    - { name: KC,               value: "${{ github.event.inputs.keycloak_url }}" }
+                    - { name: KC_REALM,         value: "${KC_REALM}" }
+                    - { name: KC_CLIENT_ID,     value: "${KC_CLIENT_ID}" }
+                    - { name: KC_CLIENT_SECRET, value: "${KC_CLIENT_SECRET}" }
+                    - { name: SCRIPT_B64,       value: "${SCRIPT_B64}" }
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      apk add --no-cache bash curl python3 >/dev/null
+                      mkdir -p /tmp/seed
+                      printf '%s' "\$SCRIPT_B64" | base64 -d > /tmp/seed/run.sh
+                      chmod +x /tmp/seed/run.sh
+                      bash /tmp/seed/run.sh
+          EOF
+
+          if az containerapp job show -n mvhd-edc-seed -g "$RESOURCE_GROUP" -o none 2>/dev/null; then
+            az containerapp job delete -n mvhd-edc-seed -g "$RESOURCE_GROUP" --yes -o none
+          fi
+          az containerapp job create -n mvhd-edc-seed -g "$RESOURCE_GROUP" --yaml /tmp/seed-job.yaml -o none
+
+          EXEC=$(az containerapp job start -n mvhd-edc-seed -g "$RESOURCE_GROUP" --query "name" -o tsv)
+          echo "started exec: $EXEC"
+          for i in $(seq 1 60); do
+            STATUS=$(az containerapp job execution show -n mvhd-edc-seed -g "$RESOURCE_GROUP" \
+              --job-execution-name "$EXEC" --query "properties.status" -o tsv 2>/dev/null || echo Pending)
+            echo "[$i] seed status: $STATUS"
+            case "$STATUS" in
+              Succeeded) echo "seed Succeeded"; break ;;
+              Failed|Canceled) echo "seed $STATUS"; break ;;
+            esac
+            sleep 5
+          done
+
+          # Always tail the job logs into the run log + step summary for
+          # debugging, regardless of pass/fail.
+          {
+            echo "## Seed job logs"
+            echo ""
+            echo '```'
+            az containerapp job execution show -n mvhd-edc-seed -g "$RESOURCE_GROUP" \
+              --job-execution-name "$EXEC" \
+              --query "properties.{status:status, startTime:startTime, endTime:endTime}" -o yaml
+            echo ""
+            # Job container logs (raw — ACA wraps each line in JSON
+            # with timestamp + log; readable enough for debugging)
+            az containerapp logs show --type=console \
+              --name mvhd-edc-seed -g "$RESOURCE_GROUP" --tail 200 \
+              2>/dev/null || true
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+          [ "$STATUS" = "Succeeded" ] || exit 1
+
+      - name: Cleanup seed job
+        if: always()
+        run: |
+          az containerapp job delete -n mvhd-edc-seed -g "$RESOURCE_GROUP" --yes -o none || true
+
+      # Optional: flip TCK_INFRA_OPTIONAL=false on the proxy so future
+      # runs treat unreachable infra as red `fail` instead of neutral
+      # blue `skip`. Per ADR-024 Phase 4. Off by default — only flip
+      # once the seed is verified working end to end.
+      - name: Flip TCK_INFRA_OPTIONAL on the proxy (optional)
+        if: ${{ github.event.inputs.flip_tck_optional == 'true' }}
+        run: |
+          az containerapp update -n mvhd-neo4j-proxy -g "$RESOURCE_GROUP" \
+            --set-env-vars TCK_INFRA_OPTIONAL=false -o none
+          echo "TCK_INFRA_OPTIONAL=false set on mvhd-neo4j-proxy"

--- a/scripts/azure/05-edc-seed.sh
+++ b/scripts/azure/05-edc-seed.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Seed 5 EHDS ParticipantContexts into IdentityHub on Azure
+# =============================================================================
+# Mirrors `jad/seed-all.sh` phases 2-3 (participant + key-pair creation)
+# against the ACA-internal IdentityHub. Idempotent: skips participants that
+# already exist (POST returns 409, treated as OK).
+#
+# Auth: Keycloak realm `edcv` client_credentials grant against the `admin`
+# client (same flow the neo4j-proxy uses for the TCK probe). IdentityHub
+# validates the bearer token via EDC_IAM_OAUTH2_JWKS_URL.
+#
+# Usage (any environment with curl + python3 + jq):
+#
+#   IH=http://mvhd-identityhub:7082/api/identity              \
+#   KC=https://auth.ehds.mabu.red                             \
+#   KC_REALM=edcv                                             \
+#   KC_CLIENT_ID=admin                                        \
+#   KC_CLIENT_SECRET=edc-v-admin-secret                       \
+#   bash scripts/azure/05-edc-seed.sh
+#
+# In CI: invoked from .github/workflows/edc-seed-participants.yml as a
+# one-shot ACA Job (since IH is internal-only).
+# =============================================================================
+set -uo pipefail
+
+IH="${IH:?IH must be set, e.g. http://mvhd-identityhub:7082/api/identity}"
+KC="${KC:?KC must be set, e.g. https://auth.ehds.mabu.red}"
+KC_REALM="${KC_REALM:-edcv}"
+KC_CLIENT_ID="${KC_CLIENT_ID:-admin}"
+KC_CLIENT_SECRET="${KC_CLIENT_SECRET:-edc-v-admin-secret}"
+
+# Five participants, matching jad/seed-health-tenants.sh and the names the
+# TCK probe iterates over in services/neo4j-proxy/src/index.ts.
+PARTICIPANTS=(
+  "alpha-klinik|did:web:alpha-klinik.de:participant"
+  "pharmaco|did:web:pharmaco.de:research"
+  "medreg|did:web:medreg.de:hdab"
+  "lmc|did:web:lmc.nl:clinic"
+  "irs|did:web:irs.fr:hdab"
+)
+
+log()  { printf '[seed] %s\n' "$*"; }
+fail() { printf '[seed] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── 1. Wait for IH to answer ────────────────────────────────────────────────
+log "Probing IH at $IH ..."
+for i in $(seq 1 30); do
+  CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$IH/v1alpha/participants" || echo 000)
+  if [ "$CODE" != "000" ]; then
+    log "  IH responding (HTTP $CODE)"
+    break
+  fi
+  log "  attempt $i: not yet, sleeping 5s"
+  sleep 5
+done
+[ "$CODE" = "000" ] && fail "IH never responded at $IH"
+
+# ── 2. Get an admin Bearer token ────────────────────────────────────────────
+log "Requesting admin token from $KC/realms/$KC_REALM ..."
+TOKEN=$(curl -sS -X POST \
+  "$KC/realms/$KC_REALM/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=$KC_CLIENT_ID&client_secret=$KC_CLIENT_SECRET" \
+  | python3 -c "import json,sys; t=json.load(sys.stdin); print(t.get('access_token',''))")
+
+[ -z "$TOKEN" ] && fail "Could not obtain admin token from Keycloak"
+log "  got token (${#TOKEN} chars)"
+
+AUTHZ=(-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json")
+
+# ── 3. Seed each participant ────────────────────────────────────────────────
+CREATED=0
+SKIPPED=0
+FAILED=0
+
+for entry in "${PARTICIPANTS[@]}"; do
+  PID="${entry%%|*}"
+  DID="${entry##*|}"
+  log "POST participant $PID  (did=$DID)"
+
+  PAYLOAD=$(cat <<JSON
+{
+  "roles": [],
+  "active": true,
+  "did": "$DID",
+  "participantId": "$PID",
+  "key": {
+    "keyId": "$PID-key-1",
+    "privateKeyAlias": "$PID-private-key-alias",
+    "publicKeyAlias": "$PID-public-key-alias",
+    "type": "EC",
+    "curve": "secp256r1"
+  }
+}
+JSON
+)
+
+  HTTP=$(curl -sS -o /tmp/ih.out -w '%{http_code}' \
+    -X POST "$IH/v1alpha/participants" \
+    "${AUTHZ[@]}" \
+    --data-binary "$PAYLOAD")
+
+  case "$HTTP" in
+    200|201|204)
+      log "  ✓ $PID created (HTTP $HTTP)"
+      CREATED=$((CREATED + 1))
+      ;;
+    409)
+      log "  · $PID already exists (HTTP 409)"
+      SKIPPED=$((SKIPPED + 1))
+      ;;
+    *)
+      log "  ✗ $PID failed (HTTP $HTTP)"
+      head -c 500 /tmp/ih.out 2>/dev/null || true
+      printf '\n'
+      FAILED=$((FAILED + 1))
+      ;;
+  esac
+done
+
+# ── 4. Final state + summary ────────────────────────────────────────────────
+log ""
+log "Final IH participant list:"
+curl -sS "${AUTHZ[@]}" "$IH/v1alpha/participants" \
+  | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    if isinstance(data, list):
+        for p in data:
+            pid = p.get('participantContextId') or p.get('participantId') or '?'
+            did = p.get('did') or '?'
+            active = p.get('active') if 'active' in p else p.get('isActive', '?')
+            print(f'  - {pid:<14} did={did:<40} active={active}')
+        print(f'  total: {len(data)}')
+    else:
+        print(json.dumps(data, indent=2)[:500])
+except Exception as e:
+    print(f'(could not parse response: {e})', file=sys.stderr)
+" || true
+
+log ""
+log "summary  created=$CREATED  skipped=$SKIPPED  failed=$FAILED"
+[ "$FAILED" -gt 0 ] && fail "$FAILED participant(s) failed to create"
+log "DONE"


### PR DESCRIPTION
Phase 3 of [issue #25](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/25) and [ADR-024](../blob/main/docs/ADRs/ADR-024-full-edc-provisioning-per-participant.md). Adds the missing piece that flips the live `/compliance/tck` page DSP-2.x and DCP-2.x rows from `skipped` to `green`.

## What this PR does

| File | Purpose |
|---|---|
| `scripts/azure/05-edc-seed.sh` | Bash that POSTs 5 ParticipantContexts (alpha-klinik, pharmaco, medreg, lmc, irs) into IdentityHub at `/v1alpha/participants`. Idempotent. |
| `.github/workflows/edc-seed-participants.yml` | Wraps the script in a one-shot ACA Job (since IH is internal-only). Manual trigger. |

## Why a one-shot ACA Job

IdentityHub's ingress is internal — there's no public hostname to POST to from a GitHub runner. The seed runs as an alpine container in the same ACA env, talks to IH over the internal network at `http://mvhd-identityhub:7082/api/identity`, and exits.

## Auth

Keycloak realm `edcv` `client_credentials` grant against the `admin` client, then `Authorization: Bearer <token>` to IH. This is the same flow `services/neo4j-proxy/src/index.ts` uses for its TCK probe — we know it works because DCP-1.1 ("IdentityHub reachable") has been green since the schema reset.

## Idempotency

The seed treats HTTP 409 (conflict) as success: re-running the workflow on a pre-seeded IH does nothing destructive. Running on a fresh IH creates the 5 contexts.

## What this PR doesn't do

- Doesn't onboard a Spanish HDAB participant (separate scope, post-demo follow-up).
- Doesn't auto-trigger after the weekly demo reset (separate small PR — add a hook to `reset-demo.yml`).
- Doesn't flip `TCK_INFRA_OPTIONAL=false` on the proxy by default — workflow has an opt-in input for that, gated until we've verified the seed end to end.

## Verification plan after merge

1. `gh workflow run edc-seed-participants.yml --repo ma3u/MinimumViableHealthDataspacev2`
2. Watch the run — final step prints the live IH participant list
3. Open `https://ehds.mabu.red/compliance/tck` — expect DSP-2.x (5 rows) and DCP-2.x (5 rows) and DCP-3.1 to flip from blue `skipped` to green `pass`
4. If green: re-run the workflow with `flip_tck_optional=true` to remove the skip-when-unreachable safety net

If the IH POST shape needs adjustment (EDC IH v0.13.x has a slightly different `ParticipantContext` schema than I'm sending), the workflow's step summary dumps the job logs so we can iterate without redeploying.