### PR TITLE
fix(workflow): edc-seed — use azure-cli base image + LA log query

### DIFF
--- a/.github/workflows/edc-seed-participants.yml
+++ b/.github/workflows/edc-seed-participants.yml
@@ -75,10 +75,10 @@ jobs:
         run: |
           ENV_ID=$(az containerapp env show -n "$ACA_ENV" -g "$RESOURCE_GROUP" \
                      --query "id" -o tsv)
-          # Read the canonical script and inline it into the job's args, so
-          # the job's container has no image-build dependency. We use a
-          # plain alpine + curl + python3 image that's already on the
-          # mirror used elsewhere.
+          # Inline the canonical seed script via base64. Image: Microsoft's
+          # azure-cli (has bash + curl + python3 all baked in — no apk
+          # install needed, which avoids alpine's outbound-during-startup
+          # uncertainty). It's bigger but reliable.
           SCRIPT_B64=$(base64 < scripts/azure/05-edc-seed.sh | tr -d '\n')
 
           cat > /tmp/seed-job.yaml <<EOF
@@ -95,8 +95,8 @@ jobs:
             template:
               containers:
                 - name: seed
-                  image: alpine:3.20
-                  resources: { cpu: 0.25, memory: 0.5Gi }
+                  image: mcr.microsoft.com/azure-cli:latest
+                  resources: { cpu: 0.5, memory: 1Gi }
                   env:
                     - { name: IH,               value: "${IH_INTERNAL_URL}" }
                     - { name: KC,               value: "${{ github.event.inputs.keycloak_url }}" }
@@ -104,13 +104,17 @@ jobs:
                     - { name: KC_CLIENT_ID,     value: "${KC_CLIENT_ID}" }
                     - { name: KC_CLIENT_SECRET, value: "${KC_CLIENT_SECRET}" }
                     - { name: SCRIPT_B64,       value: "${SCRIPT_B64}" }
-                  command: ["/bin/sh", "-c"]
+                  command: ["/bin/bash", "-c"]
                   args:
                     - |
-                      apk add --no-cache bash curl python3 >/dev/null
+                      set -eo pipefail
                       mkdir -p /tmp/seed
                       printf '%s' "\$SCRIPT_B64" | base64 -d > /tmp/seed/run.sh
                       chmod +x /tmp/seed/run.sh
+                      echo "=== seed env ==="
+                      echo "IH=\$IH"
+                      echo "KC=\$KC (realm \$KC_REALM client \$KC_CLIENT_ID)"
+                      echo "=== running /tmp/seed/run.sh ==="
                       bash /tmp/seed/run.sh
           EOF
 
@@ -132,21 +136,31 @@ jobs:
             sleep 5
           done
 
-          # Always tail the job logs into the run log + step summary for
-          # debugging, regardless of pass/fail.
+          # ACA Job stdout goes to Log Analytics — query it directly.
+          # `az containerapp logs show` is for apps, not jobs, so we use
+          # the LA workspace attached to the env.
+          WS_ID=$(az containerapp env show -n "$ACA_ENV" -g "$RESOURCE_GROUP" \
+                  --query "properties.appLogsConfiguration.logAnalyticsConfiguration.customerId" -o tsv)
           {
-            echo "## Seed job logs"
+            echo "## Seed job execution"
             echo ""
-            echo '```'
+            echo '```yaml'
             az containerapp job execution show -n mvhd-edc-seed -g "$RESOURCE_GROUP" \
               --job-execution-name "$EXEC" \
               --query "properties.{status:status, startTime:startTime, endTime:endTime}" -o yaml
+            echo '```'
             echo ""
-            # Job container logs (raw — ACA wraps each line in JSON
-            # with timestamp + log; readable enough for debugging)
-            az containerapp logs show --type=console \
-              --name mvhd-edc-seed -g "$RESOURCE_GROUP" --tail 200 \
-              2>/dev/null || true
+            echo "## Container logs (Log Analytics)"
+            echo ""
+            echo '```'
+            # Wait a few seconds for log ingestion, then query.
+            sleep 15
+            az monitor log-analytics query -w "$WS_ID" --analytics-query \
+              "ContainerAppConsoleLogs_CL | where ContainerAppName_s == 'mvhd-edc-seed' | order by TimeGenerated asc | project TimeGenerated, Log_s | take 200" \
+              -o tsv 2>&1 \
+              | sed 's/\\u001b\[[0-9;]*m//g' \
+              | head -200 \
+              || echo "(no logs in LA yet — try retrying or query directly)"
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Follow-up to PR #32. First live run failed in 30s without diagnostic output.

## Two fixes

1. **Base image**: `alpine:3.20` → `mcr.microsoft.com/azure-cli:latest`. Alpine needs apk install for bash/curl/python3 and may not have reliable outbound to apk repos from inside ACA at startup. The azure-cli image has bash, curl, python3, jq baked in.

2. **Log dump**: `az containerapp logs show` is for apps, not jobs. ACA Job stdout lands in Log Analytics. The workflow now queries the LA workspace directly via the env's `appLogsConfiguration` so the GH Actions Summary tab shows the actual container output.

Plus an upfront env dump in the job container so we see the resolved IH / KC values at startup.

Once this lands I'll re-trigger the workflow.