### PR TITLE
fix(workflow): edc-schema-reset — also recreate controlplane + dataplane DBs

### DIFF
--- a/.github/workflows/edc-schema-reset.yml
+++ b/.github/workflows/edc-schema-reset.yml
@@ -99,7 +99,7 @@ jobs:
                       value: postgres
                   command: ["sh", "-c"]
                   args:
-                    - "psql -c 'DROP DATABASE IF EXISTS identityhub WITH (FORCE)' && psql -c 'DROP DATABASE IF EXISTS issuerservice WITH (FORCE)' && psql -c 'CREATE DATABASE identityhub' && psql -c 'CREATE DATABASE issuerservice' && echo DONE"
+                    - "psql -c 'DROP DATABASE IF EXISTS controlplane WITH (FORCE)' && psql -c 'DROP DATABASE IF EXISTS dataplane WITH (FORCE)' && psql -c 'DROP DATABASE IF EXISTS dataplane_omop WITH (FORCE)' && psql -c 'DROP DATABASE IF EXISTS identityhub WITH (FORCE)' && psql -c 'DROP DATABASE IF EXISTS issuerservice WITH (FORCE)' && psql -c 'CREATE DATABASE controlplane' && psql -c 'CREATE DATABASE dataplane' && psql -c 'CREATE DATABASE dataplane_omop' && psql -c 'CREATE DATABASE identityhub' && psql -c 'CREATE DATABASE issuerservice' && echo DONE"
           EOF
           # Replace if it already exists, otherwise create
           if az containerapp job show -n mvhd-pgfix -g $RESOURCE_GROUP -o none 2>/dev/null; then


### PR DESCRIPTION
Discovered while debugging issue #25 seed. LA-attach restart wave on 2026-05-10 ran initdb on Postgres' Azure Files volume, wiping all EDC DBs. Workflow now handles all 5 (controlplane, dataplane, dataplane_omop, identityhub, issuerservice) instead of just IH + Issuer.