### PR TITLE
fix(seed): use keyGeneratorParams in KeyDescriptor (#25)

### DIFF
--- a/scripts/azure/05-edc-seed.sh
+++ b/scripts/azure/05-edc-seed.sh
@@ -79,10 +79,11 @@ for entry in "${PARTICIPANTS[@]}"; do
   DID="${entry##*|}"
   log "POST participant $PID  (did=$DID)"
 
-  # EDC IdentityHub v0.13.x renamed the JSON field from `participantId` to
-  # `participantContextId` (matches the path-segment used elsewhere in the
-  # API). Older builds accept both, newer builds reject the old name with
-  # HTTP 400 ValidationFailure. Send the new name.
+  # KeyDescriptor schema (jad/openapi/identity-api.yaml): IH accepts EITHER
+  # an explicit public key (publicKeyPem|publicKeyJwk) OR generator params
+  # (keyGeneratorParams) — not the inline {type, curve} shape we sent first.
+  # We let IH generate the keypair: simpler, no Vault pre-seed needed for
+  # the TCK probe path (which only iterates the participant list).
   PAYLOAD=$(cat <<JSON
 {
   "roles": [],
@@ -92,9 +93,12 @@ for entry in "${PARTICIPANTS[@]}"; do
   "key": {
     "keyId": "$PID-key-1",
     "privateKeyAlias": "$PID-private-key-alias",
-    "publicKeyAlias": "$PID-public-key-alias",
-    "type": "EC",
-    "curve": "secp256r1"
+    "active": true,
+    "type": "JsonWebKey2020",
+    "keyGeneratorParams": {
+      "algorithm": "EC",
+      "curve": "secp256r1"
+    }
   }
 }
 JSON


### PR DESCRIPTION
## Summary
- Iteration 2 of the seed payload fix. After PR #39 (`participantId` → `participantContextId`) IH accepted the id but rejected the `key` block.
- Per `jad/openapi/identity-api.yaml`, KeyDescriptor needs `keyId + privateKeyAlias + type` *and* one of `publicKeyPem | publicKeyJwk | keyGeneratorParams`. We were sending bare `{type: EC, curve: secp256r1}`, which IH does not recognise as valid generator params.
- Switched to `type: JsonWebKey2020` + `keyGeneratorParams: { algorithm: EC, curve: secp256r1 }` so IH generates the keypair internally. No Vault pre-seed needed for the TCK probe path (which only iterates the participant list).

## Diagnostic from run #25634225287
After the field rename worked:
```
[{"message":"key descriptor is invalid: Either the public key is specified (PEM or JWK), or the generator parameters are provided.",
  "type":"ValidationFailure","path":"key","invalidValue":null}]
```
All 5 POSTs failed identically with this validation error. Final IH list: `total: 0`.

## Test plan
- [ ] Merge → trigger `EDC Seed Participants` workflow
- [ ] Confirm `[seed] summary  created=5  skipped=0  failed=0`
- [ ] Confirm `Final IH participant list: total: 5`
- [ ] Verify `/compliance/tck` DSP-2.x and DCP-2.x rows flip green
- [ ] If green, optionally rerun with `flip_tck_optional=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)