### PR TITLE
fix(ih): AES encryption env + Vault bootstrap workflow (#25, blocked on IH rebuild)

### DIFF
--- a/.github/workflows/vault-bootstrap-aes.yml
+++ b/.github/workflows/vault-bootstrap-aes.yml
@@ -1,0 +1,155 @@
+name: Vault bootstrap AES key (issue #25)
+
+# Stores a 256-bit AES key under `secret/data/aes-key-alias` in the live
+# Azure Vault. EDC's IH and Issuer runtimes need this key to encrypt
+# KeyPairResource entries when a participant is created. Without it,
+# every POST /v1alpha/participants that triggers internal keypair
+# generation crashes server-side with:
+#
+#   EdcException: Failed to encrypt entries: Unsupported encryption
+#   algorithm: aes
+#
+# Mirrors what jad/bootstrap-vault.sh does locally (write content to
+# secret/data/aes-key-alias). Idempotent: safe to re-run.
+#
+# Manual trigger only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      key_alias:
+        description: "Vault key alias (must match EDC_ENCRYPTION_AES_KEY_ALIAS)"
+        type: string
+        default: "aes-key-alias"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: "azure-vault-aes"
+  cancel-in-progress: false
+
+env:
+  RESOURCE_GROUP: rg-mvhd-dev
+  ACA_ENV: mvhd-env
+
+jobs:
+  bootstrap:
+    name: Write AES key into Vault
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve Vault token from ACA secret
+        id: vault
+        run: |
+          TOKEN=$(az containerapp secret show -n mvhd-vault -g "$RESOURCE_GROUP" \
+                    --secret-name vault-root-token --query "value" -o tsv 2>/dev/null \
+                  || az containerapp show -n mvhd-vault -g "$RESOURCE_GROUP" \
+                       --query "properties.template.containers[0].env[?name=='VAULT_DEV_ROOT_TOKEN_ID'].value" -o tsv)
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Could not resolve Vault root token"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Run bootstrap as one-shot ACA Job
+        env:
+          VAULT_TOKEN: ${{ steps.vault.outputs.token }}
+          KEY_ALIAS: ${{ github.event.inputs.key_alias }}
+        run: |
+          ENV_ID=$(az containerapp env show -n "$ACA_ENV" -g "$RESOURCE_GROUP" \
+                     --query "id" -o tsv)
+          # Generate a fresh 32-byte AES key, base64-encode. Done on the
+          # runner so we never log the secret value.
+          AES_KEY_B64=$(openssl rand -base64 32)
+          echo "::add-mask::$AES_KEY_B64"
+
+          cat > /tmp/aes-bootstrap-job.yaml <<EOF
+          type: Microsoft.App/jobs
+          properties:
+            configuration:
+              triggerType: Manual
+              replicaTimeout: 120
+              replicaRetryLimit: 0
+              manualTriggerConfig:
+                replicaCompletionCount: 1
+                parallelism: 1
+              secrets:
+                - name: vault-token
+                  value: "${VAULT_TOKEN}"
+                - name: aes-key
+                  value: "${AES_KEY_B64}"
+            environmentId: ${ENV_ID}
+            template:
+              containers:
+                - name: aes-bootstrap
+                  image: curlimages/curl:8.10.1
+                  resources: { cpu: 0.25, memory: 0.5Gi }
+                  env:
+                    - { name: VAULT_ADDR, value: "http://mvhd-vault:8200" }
+                    - { name: KEY_ALIAS,  value: "${KEY_ALIAS}" }
+                    - name: VAULT_TOKEN
+                      secretRef: vault-token
+                    - name: AES_KEY_B64
+                      secretRef: aes-key
+                  command: ["sh", "-c"]
+                  args:
+                    - |
+                      set -e
+                      echo "Probing Vault..."
+                      curl -fsS -o /dev/null -w 'vault %{http_code}\n' \
+                        -H "X-Vault-Token: \$VAULT_TOKEN" \
+                        "\$VAULT_ADDR/v1/sys/health" || true
+
+                      echo "Writing AES key to secret/data/\$KEY_ALIAS ..."
+                      HTTP=\$(curl -sS -o /tmp/out -w '%{http_code}' \
+                        -X POST "\$VAULT_ADDR/v1/secret/data/\$KEY_ALIAS" \
+                        -H "X-Vault-Token: \$VAULT_TOKEN" \
+                        -H "Content-Type: application/json" \
+                        -d "{\"data\":{\"content\":\"\$AES_KEY_B64\"}}")
+                      echo "write status: \$HTTP"
+                      if [ "\$HTTP" != "200" ] && [ "\$HTTP" != "204" ]; then
+                        head -c 500 /tmp/out; echo
+                        echo "FAILED"
+                        exit 1
+                      fi
+
+                      echo "Verifying readback..."
+                      curl -sS -H "X-Vault-Token: \$VAULT_TOKEN" \
+                        "\$VAULT_ADDR/v1/secret/data/\$KEY_ALIAS" \
+                        | head -c 200
+                      echo
+                      echo DONE
+          EOF
+
+          if az containerapp job show -n mvhd-vault-aes -g "$RESOURCE_GROUP" -o none 2>/dev/null; then
+            az containerapp job delete -n mvhd-vault-aes -g "$RESOURCE_GROUP" --yes -o none
+          fi
+          az containerapp job create -n mvhd-vault-aes -g "$RESOURCE_GROUP" --yaml /tmp/aes-bootstrap-job.yaml -o none
+          EXEC=$(az containerapp job start -n mvhd-vault-aes -g "$RESOURCE_GROUP" --query "name" -o tsv)
+          echo "started exec: $EXEC"
+          for i in $(seq 1 30); do
+            STATUS=$(az containerapp job execution show -n mvhd-vault-aes -g "$RESOURCE_GROUP" \
+                       --job-execution-name "$EXEC" --query "properties.status" -o tsv 2>/dev/null || echo Pending)
+            echo "[$i] status: $STATUS"
+            case "$STATUS" in
+              Succeeded) echo "AES key bootstrap Succeeded"; exit 0 ;;
+              Failed|Canceled) echo "AES key bootstrap $STATUS"; exit 1 ;;
+            esac
+            sleep 4
+          done
+          echo "Timed out"; exit 1
+
+      - name: Cleanup job
+        if: always()
+        run: |
+          az containerapp job delete -n mvhd-vault-aes -g "$RESOURCE_GROUP" --yes -o none || true

--- a/scripts/azure/04-edc-services.sh
+++ b/scripts/azure/04-edc-services.sh
@@ -177,6 +177,7 @@ az containerapp create \
     "EDC_SQL_SCHEMA_AUTOCREATE=true" \
     "EDC_VAULT_HASHICORP_URL=${VAULT_URL:-}" \
     "EDC_VAULT_HASHICORP_TOKEN=${VAULT_ROOT_TOKEN}" \
+    "EDC_ENCRYPTION_AES_KEY_ALIAS=aes-key-alias" \
     "EDC_IAM_OAUTH2_JWKS_URL=${KEYCLOAK_PUBLIC_URL:-}/realms/edcv/protocol/openid-connect/certs" \
     "WEB_HTTP_PORT=7081" \
     "WEB_HTTP_IDENTITY_PORT=7082" \
@@ -201,6 +202,7 @@ az containerapp create \
     "EDC_SQL_SCHEMA_AUTOCREATE=true" \
     "EDC_VAULT_HASHICORP_URL=${VAULT_URL:-}" \
     "EDC_VAULT_HASHICORP_TOKEN=${VAULT_ROOT_TOKEN}" \
+    "EDC_ENCRYPTION_AES_KEY_ALIAS=aes-key-alias" \
     "EDC_IAM_OAUTH2_JWKS_URL=${KEYCLOAK_PUBLIC_URL:-}/realms/edcv/protocol/openid-connect/certs" \
     "WEB_HTTP_PORT=10013" \
   -o none


### PR DESCRIPTION
## Summary
- Lands the **two pieces a PR can ship** for the issue #25 Option C participant-seed work.
- Adds `EDC_ENCRYPTION_AES_KEY_ALIAS=aes-key-alias` to both Identity Hub and Issuer Service ACA env-vars in `04-edc-services.sh`.
- Adds `.github/workflows/vault-bootstrap-aes.yml`: one-shot ACA Job that writes a 256-bit AES key to `secret/data/aes-key-alias` in the live Vault. Mirrors `jad/bootstrap-vault.sh`.

## Diagnostic chain
1. **PR #39** — fixed `participantId` → `participantContextId` (IH v0.13.x JSON rename). Run #25634225287 confirmed payload accepted at the id field, then HTTP 400 on the `key` block.
2. **PR #40** — fixed `key` block to use `keyGeneratorParams: { algorithm: EC, curve: secp256r1 }` per `jad/openapi/identity-api.yaml`. Run #25634400922 confirmed validation passed; surfaced server-side HTTP 500.
3. **This PR** — server-side trace from `mvhd-identityhub` LA logs (timestamp `2026-05-10T16:55:08`):

   ```
   org.eclipse.edc.spi.EdcException: Failed to encrypt entries:
     Unsupported encryption algorithm: aes
   ```

   Root cause: the IH JAR currently in ACR was built from `connector/identityhub/` with only `identity-hub-core` + `identity-hub-did`, missing the AES extension that ships with the upstream `identityhub-oauth2-bom`. `vendor/jad/launchers/identity-hub/build.gradle.kts` (the JAD launcher we mirror locally) uses the BOM, so JAD never hit this.

## Blocked on (manual step, not in this PR)
The `connector/` tree is gitignored, so the IH JAR rebuild has to run locally:

```bash
cd connector/identityhub
# add to build.gradle.kts dependencies:
#   runtimeOnly("org.eclipse.edc:identityhub-oauth2-bom:$edcVersion")
#   runtimeOnly("org.eclipse.edc:identityhub-feature-sql-bom:$edcVersion")
../../gradlew :identityhub:shadowJar
docker buildx build --platform linux/amd64 \
  -t mvhdacr.azurecr.io/health-dataspace/identityhub:latest \
  --push .
```

Once the new IH image is in ACR:

```bash
gh workflow run vault-bootstrap-aes.yml
az containerapp revision restart -n mvhd-identityhub -g rg-mvhd-dev
gh workflow run edc-seed-participants.yml -f keycloak_url=https://auth.ehds.mabu.red
```

Expected: `[seed] summary  created=5  skipped=0  failed=0` and `/compliance/tck` DSP-2.x + DCP-2.x rows flip green.

## Test plan
- [ ] Merge this PR
- [ ] Manual IH JAR rebuild + push to ACR (per "Blocked on" above)
- [ ] Re-run `04-edc-services.sh`'s IH section (or apply env var via `az containerapp update`)
- [ ] Run `vault-bootstrap-aes.yml` workflow → expect `Succeeded`
- [ ] Run `edc-seed-participants.yml` → expect 5 created
- [ ] Verify TCK page DSP-2.x + DCP-2.x flip from blue to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)