### PR TITLE
fix(workflow): keypairs endpoint is PUT not POST (#25)

### DIFF
--- a/.github/workflows/edc-add-keypairs.yml
+++ b/.github/workflows/edc-add-keypairs.yml
@@ -95,7 +95,7 @@ jobs:
                           \"keyGeneratorParams\": { \"algorithm\": \"EC\", \"curve\": \"secp256r1\" }
                         }"
                         HTTP=\$(curl -sS -o /tmp/out -w '%{http_code}' \
-                          -X POST "\$IH/v1alpha/participants/\$P/keypairs" \
+                          -X PUT "\$IH/v1alpha/participants/\$P/keypairs?makeDefault=true" \
                           -H "Authorization: Bearer \$TOKEN" \
                           -H "Content-Type: application/json" \
                           -d "\$PAYLOAD")


### PR DESCRIPTION
Per OpenAPI spec, /v1alpha/participants/{pid}/keypairs takes PUT (operationId: addKeyPair) and supports ?makeDefault=true. POST returned HTTP 405.