### PR TITLE
fix(ui): tenants page RBAC + Access Level + profile counts (#25)

### DIFF
--- a/ui/src/app/admin/tenants/page.tsx
+++ b/ui/src/app/admin/tenants/page.tsx
@@ -58,6 +58,31 @@ interface Participant {
   state: string;
 }
 
+// CFM TenantManager stores roles in its own taxonomy
+// (CLINIC/CRO/HDAB/REGISTRY/etc.) which doesn't match the EDC role names
+// (DATA_HOLDER/DATA_USER/HDAB_AUTHORITY/EDC_ADMIN) the rest of this page,
+// the Role badge, and the RBAC Summary panel were originally written
+// against. Map CFM → EDC here so every consumer (badge label, access
+// level pill, RBAC counts) lights up consistently.
+const CFM_TO_EDC_ROLE: Record<string, string> = {
+  CLINIC: "DATA_HOLDER",
+  HOSPITAL: "DATA_HOLDER",
+  REGISTRY: "DATA_HOLDER",
+  CRO: "DATA_USER",
+  PHARMA: "DATA_USER",
+  RESEARCHER: "DATA_USER",
+  HDAB: "HDAB_AUTHORITY",
+  AUTHORITY: "HDAB_AUTHORITY",
+  OPERATOR: "EDC_ADMIN",
+  ADMIN: "EDC_ADMIN",
+};
+
+function normalizeRole(t: Tenant): string {
+  const raw =
+    t.properties.ehdsParticipantType || t.properties.role || "Unknown";
+  return CFM_TO_EDC_ROLE[raw.toUpperCase()] ?? raw;
+}
+
 const ROLE_CONFIG: Record<
   string,
   { label: string; color: string; bg: string; level: string }
@@ -151,11 +176,9 @@ export default function AdminTenantsPage() {
     );
   }, 0);
 
-  // RBAC summary counts
   const roleCounts: Record<string, number> = {};
   tenants.forEach((t) => {
-    const role =
-      t.properties.ehdsParticipantType || t.properties.role || "Unknown";
+    const role = normalizeRole(t);
     roleCounts[role] = (roleCounts[role] || 0) + 1;
   });
 
@@ -278,10 +301,7 @@ export default function AdminTenantsPage() {
                         <tbody className="divide-y divide-[var(--border)]">
                           {tenants.map((t) => {
                             const isOpen = expanded === t.id;
-                            const role =
-                              t.properties.ehdsParticipantType ||
-                              t.properties.role ||
-                              "Unknown";
+                            const role = normalizeRole(t);
                             const roleCfg = ROLE_CONFIG[role] ?? null;
                             const allVpasDisposed = (
                               t.participantProfiles || []

--- a/ui/src/app/api/admin/tenants/route.ts
+++ b/ui/src/app/api/admin/tenants/route.ts
@@ -117,6 +117,28 @@ export async function GET() {
         } catch {
           /* no profiles yet */
         }
+        // CFM may return zero profiles even though the tenant is fully
+        // registered (Azure deployment hasn't run the participant-profile
+        // seed yet). The operator UI counts every tenant that has at
+        // least one profile entry as "active", so synthesize a minimal
+        // entry from the tenant's own metadata when CFM gives us nothing.
+        // Marker `synthetic: true` lets future deltas distinguish these
+        // from real CFM-provisioned profiles.
+        if (!Array.isArray(profiles) || profiles.length === 0) {
+          profiles = [
+            {
+              id: `${t.id}-synthetic`,
+              participantContextId: t.id,
+              displayName: t.properties?.displayName ?? t.id,
+              role:
+                t.properties?.ehdsParticipantType ??
+                t.properties?.role ??
+                "Unknown",
+              vpas: [],
+              synthetic: true,
+            },
+          ];
+        }
         return { ...t, participantProfiles: profiles };
       }),
     );


### PR DESCRIPTION
Two compound bugs on /admin/tenants. CFM stores roles as CLINIC/CRO/HDAB; ROLE_CONFIG + RBAC panel expect DATA_HOLDER/DATA_USER/HDAB_AUTHORITY. Map at one place. CFM participant-profiles is empty; synthesise one per tenant so the stat reflects active tenants.