### PR TITLE
fix(auth): clear Keycloak SSO session on sign-out (#52)

### DIFF
--- a/ui/__tests__/e2e/journeys/35-logout-session-clearing.spec.ts
+++ b/ui/__tests__/e2e/journeys/35-logout-session-clearing.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Journey Group S — Logout & SSO Session Clearing (J820–J829)
+ *
+ * Regression coverage for issue #52:
+ *   "Logout does not clear the Keycloak SSO session — re-login silently
+ *    restores the previous user."
+ *
+ * The bug: the Sign out button passed Keycloak's cross-origin end-session
+ * URL as `signOut({ callbackUrl })`. NextAuth v4 rejects cross-origin
+ * callback URLs, so the browser never reached Keycloak and the SSO cookie
+ * (KEYCLOAK_IDENTITY / KEYCLOAK_SESSION) survived. The next sign-in then
+ * silently re-authenticated the same user with no login form.
+ *
+ * Expected after the fix: signing out ends the Keycloak SSO session, so a
+ * subsequent sign-in shows the Keycloak login form and a *different* user
+ * can authenticate — no incognito window needed.
+ *
+ * Prerequisites: Keycloak running with the EDCV realm users.
+ * Skipped automatically when Keycloak is unreachable.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { T, skipIfKeycloakDown, loginAs } from "./helpers";
+
+/** Sign out through the UserMenu dropdown and wait for the logout to settle. */
+async function signOutViaUi(page: Page) {
+  await page.goto("/", { waitUntil: "networkidle" });
+  // Open the user menu (nav-bar button carries aria-label="User menu").
+  await page.getByRole("button", { name: /user menu/i }).click();
+  const signOut = page.getByRole("button", { name: /^sign out$/i });
+  await expect(signOut).toBeVisible({ timeout: T });
+  await signOut.click();
+  // The fix performs: signOut({ redirect: false }) → hard-redirect to
+  // Keycloak's end-session endpoint → post_logout_redirect_uri back to the
+  // app. Wait for the round-trip to land back on the app origin.
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+  const baseHost = new URL(baseUrl).hostname.replace(/\./g, "\\.");
+  await page.waitForURL(new RegExp(baseHost), { timeout: 20_000 });
+}
+
+/** Read the role array from the NextAuth session endpoint. */
+async function sessionRoles(page: Page): Promise<string[]> {
+  try {
+    const res = await page.request.get("/api/auth/session");
+    if (!res.ok()) return [];
+    const data = (await res.json()) as { roles?: string[] };
+    return data.roles ?? [];
+  } catch {
+    return [];
+  }
+}
+
+test.describe("Journey S — Logout clears the Keycloak SSO session", () => {
+  test.beforeEach(async () => {
+    await skipIfKeycloakDown();
+  });
+
+  test("J820 — sign out fully clears the NextAuth session", async ({
+    page,
+  }) => {
+    await loginAs(page, "clinicuser", "clinicuser");
+    expect(await sessionRoles(page)).toContain("DATA_HOLDER");
+
+    await signOutViaUi(page);
+
+    // No roles → NextAuth session cookie is gone.
+    expect(await sessionRoles(page)).toHaveLength(0);
+  });
+
+  test("J821 — after logout, a DIFFERENT user can sign in (no stale SSO)", async ({
+    page,
+  }) => {
+    // Sign in as the first user.
+    await loginAs(page, "clinicuser", "clinicuser");
+    expect(await sessionRoles(page)).toContain("DATA_HOLDER");
+
+    // Sign out — must end the Keycloak SSO session, not only the app cookie.
+    await signOutViaUi(page);
+
+    // Sign in again as a DIFFERENT user. loginAs() asserts the Keycloak
+    // username field is visible — if the SSO session had survived (the bug),
+    // Keycloak would skip the login form and this step would fail or restore
+    // clinicuser instead.
+    await loginAs(page, "researcher", "researcher");
+
+    const roles = await sessionRoles(page);
+    expect(roles).toContain("DATA_USER");
+    // The previous user's role must NOT leak into the new session.
+    expect(roles).not.toContain("DATA_HOLDER");
+  });
+
+  test("J822 — re-login as the SAME user still presents the login form", async ({
+    page,
+  }) => {
+    await loginAs(page, "researcher", "researcher");
+    await signOutViaUi(page);
+
+    // loginAs() fails if the Keycloak login form is skipped — so a passing
+    // run proves the SSO session was cleared even for same-user re-login.
+    await loginAs(page, "researcher", "researcher");
+    expect(await sessionRoles(page)).toContain("DATA_USER");
+  });
+});

--- a/ui/__tests__/unit/components/UserMenu.test.tsx
+++ b/ui/__tests__/unit/components/UserMenu.test.tsx
@@ -273,7 +273,54 @@ describe("UserMenu", () => {
   // ── Sign out ─────────────────────────────────────────────────────
 
   describe("sign out", () => {
+    // signOut() returns a Promise — the component chains .then() on it for
+    // the Keycloak hard-redirect, so the mock must resolve.
+    beforeEach(() => {
+      mockSignOut.mockResolvedValue(undefined);
+    });
+
+    // ── window.location stub ──────────────────────────────────────
+    // The fix navigates the browser to Keycloak's end-session endpoint via
+    // `window.location.href = …`. jsdom does not implement cross-origin
+    // navigation, so we replace window.location with a plain writable object
+    // and read back the href the component set.
+    const realLocation = window.location;
+    function stubLocation() {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: {
+          ...realLocation,
+          origin: "https://ehds.mabu.red",
+          href: "https://ehds.mabu.red/",
+          assign: vi.fn(),
+          replace: vi.fn(),
+        },
+      });
+    }
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: realLocation,
+      });
+    });
+
+    /** Stub /api/keycloak-config so UserMenu has a Keycloak public URL. */
+    function stubKeycloakConfig(
+      publicUrl = "https://keycloak.ehds.mabu.red/realms/edcv",
+      clientId = "health-dataspace-ui",
+    ) {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ publicUrl, clientId }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
     it("calls signOut with callbackUrl '/' when no Keycloak URL set", async () => {
+      stubLocation();
       mockUseSession.mockReturnValue(sessionWith("User", "u@example.com", []));
       const user = userEvent.setup();
       render(<UserMenu />);
@@ -283,15 +330,22 @@ describe("UserMenu", () => {
       expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
     });
 
-    it("builds Keycloak logout URL when /api/keycloak-config returns config", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          publicUrl: "http://keycloak.localhost/realms/EDCV",
-          clientId: "my-client",
-        }),
-      });
-      vi.stubGlobal("fetch", fetchMock);
+    /**
+     * REGRESSION — issue #52.
+     *
+     * Reproduces "logout then re-login keeps the previous user": the sign-out
+     * MUST end Keycloak's SSO session, not just the NextAuth app cookie.
+     *
+     * Before the fix, the component called `signOut({ callbackUrl: logoutUrl })`
+     * with a cross-origin Keycloak URL. NextAuth v4 rejects cross-origin
+     * callback URLs, so the browser never reached Keycloak and the SSO cookie
+     * survived. This test asserts the correct flow instead:
+     *   1. signOut is invoked with `{ redirect: false }` (NOT a callbackUrl), and
+     *   2. the browser is hard-redirected to Keycloak's end-session endpoint.
+     */
+    it("hard-redirects the browser to Keycloak's end-session endpoint on sign out", async () => {
+      stubLocation();
+      stubKeycloakConfig();
 
       mockUseSession.mockReturnValue(
         sessionWith("Logout User", "logout@example.com", []),
@@ -300,51 +354,93 @@ describe("UserMenu", () => {
       render(<UserMenu />);
 
       await waitFor(() =>
-        expect(fetchMock).toHaveBeenCalledWith("/api/keycloak-config"),
+        expect(window.fetch).toHaveBeenCalledWith("/api/keycloak-config"),
       );
 
       await user.click(screen.getByText("Logout User"));
       await user.click(screen.getByText("Sign out"));
 
-      expect(mockSignOut).toHaveBeenCalledTimes(1);
-      const { callbackUrl } = mockSignOut.mock.calls[0][0];
-      expect(callbackUrl).toContain(
-        "http://keycloak.localhost/realms/EDCV/protocol/openid-connect/logout",
+      // 1. signOut must NOT receive the cross-origin Keycloak URL as a
+      //    callbackUrl — NextAuth would silently drop it.
+      expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+      expect(mockSignOut).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackUrl: expect.stringContaining("openid-connect/logout"),
+        }),
       );
-      expect(callbackUrl).toContain("post_logout_redirect_uri=");
-      expect(callbackUrl).toContain("client_id=my-client");
+
+      // 2. After signOut resolves, the browser is sent to Keycloak's
+      //    end-session endpoint so the SSO cookie is destroyed.
+      await waitFor(() =>
+        expect(window.location.href).toContain(
+          "https://keycloak.ehds.mabu.red/realms/edcv/protocol/openid-connect/logout",
+        ),
+      );
+      expect(window.location.href).toContain("post_logout_redirect_uri=");
+      expect(window.location.href).toContain("client_id=health-dataspace-ui");
+
+      vi.unstubAllGlobals();
+    });
+
+    it("includes id_token_hint in the logout URL when a session id_token exists", async () => {
+      stubLocation();
+      stubKeycloakConfig();
+
+      mockUseSession.mockReturnValue({
+        data: {
+          user: { name: "Token User", email: "tok@example.com" },
+          roles: [],
+          idToken: "eyJhbGciOiJ.fake.idtoken",
+        },
+        status: "authenticated" as const,
+      });
+      const user = userEvent.setup();
+      render(<UserMenu />);
+
+      await waitFor(() =>
+        expect(window.fetch).toHaveBeenCalledWith("/api/keycloak-config"),
+      );
+
+      await user.click(screen.getByText("Token User"));
+      await user.click(screen.getByText("Sign out"));
+
+      await waitFor(() =>
+        expect(window.location.href).toContain("openid-connect/logout"),
+      );
+      expect(window.location.href).toContain(
+        "id_token_hint=eyJhbGciOiJ.fake.idtoken",
+      );
 
       vi.unstubAllGlobals();
     });
 
     it("passes clientId from runtime config into logout URL", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          publicUrl: "http://keycloak.localhost/realms/test",
-          clientId: "health-dataspace-ui",
-        }),
-      });
-      vi.stubGlobal("fetch", fetchMock);
+      stubLocation();
+      stubKeycloakConfig(
+        "https://keycloak.ehds.mabu.red/realms/test",
+        "health-dataspace-ui",
+      );
 
       mockUseSession.mockReturnValue(sessionWith("U", "u@test.com", []));
       const user = userEvent.setup();
       render(<UserMenu />);
 
       await waitFor(() =>
-        expect(fetchMock).toHaveBeenCalledWith("/api/keycloak-config"),
+        expect(window.fetch).toHaveBeenCalledWith("/api/keycloak-config"),
       );
 
       await user.click(screen.getByText("U"));
       await user.click(screen.getByText("Sign out"));
 
-      const { callbackUrl } = mockSignOut.mock.calls[0][0];
-      expect(callbackUrl).toContain("client_id=health-dataspace-ui");
+      await waitFor(() =>
+        expect(window.location.href).toContain("client_id=health-dataspace-ui"),
+      );
 
       vi.unstubAllGlobals();
     });
 
     it("closes dropdown after sign-out click", async () => {
+      stubLocation();
       mockUseSession.mockReturnValue(
         sessionWith("Closer", "c@example.com", []),
       );

--- a/ui/__tests__/unit/lib/auth-callbacks.test.ts
+++ b/ui/__tests__/unit/lib/auth-callbacks.test.ts
@@ -41,6 +41,31 @@ describe("authOptions callbacks", () => {
       expect(result.sub).toBe("user-1");
     });
 
+    // Regression — issue #52: the id_token must be persisted on the JWT so
+    // the session callback can expose it for RP-initiated Keycloak logout.
+    it("persists the id_token on initial sign-in", async () => {
+      const token: JWT = { sub: "user-1" };
+      const account = {
+        access_token: "at-123",
+        refresh_token: "rt-456",
+        id_token: "eyJhbGciOiJ.fake.idtoken",
+        type: "oauth" as const,
+        provider: "keycloak",
+        providerAccountId: "user-1",
+      };
+      const profile = { sub: "user-1", name: "Test User" };
+
+      const result = await jwtCallback({
+        token,
+        account,
+        profile,
+        user: { id: "user-1" },
+        trigger: "signIn",
+      });
+
+      expect(result.idToken).toBe("eyJhbGciOiJ.fake.idtoken");
+    });
+
     it("returns token unchanged on subsequent requests", async () => {
       const token: JWT = {
         sub: "user-1",
@@ -128,6 +153,33 @@ describe("authOptions callbacks", () => {
       });
 
       expect((result as any).roles).toEqual([]);
+    });
+
+    // Regression — issue #52: the id_token must reach the session so the
+    // client can pass it as id_token_hint to Keycloak's end-session endpoint
+    // on sign-out (clears the SSO session, not just the app cookie).
+    it("exposes the id_token from the token on the session", async () => {
+      const session = {
+        user: { id: "user-3", name: "Test", email: "test@test.com" },
+        expires: "2099-01-01",
+        roles: [] as string[],
+      } as Session;
+      const token: JWT = {
+        sub: "user-3",
+        roles: ["EDC_ADMIN"],
+        accessToken: "at-123",
+        idToken: "eyJhbGciOiJ.fake.idtoken",
+      };
+
+      const result = await sessionCallback({
+        session,
+        token,
+        user: { id: "user-3", email: "test@test.com", emailVerified: null },
+        trigger: "update",
+        newSession: undefined,
+      });
+
+      expect((result as any).idToken).toBe("eyJhbGciOiJ.fake.idtoken");
     });
   });
 });

--- a/ui/src/components/UserMenu.tsx
+++ b/ui/src/components/UserMenu.tsx
@@ -79,6 +79,46 @@ function displayRolesFor(roles: string[]): string[] {
 }
 
 /**
+ * Builds the Keycloak RP-initiated logout (end-session) URL.
+ *
+ * Passing `id_token_hint` lets Keycloak end the SSO session immediately
+ * without showing a logout-confirmation prompt; `client_id` is the fallback
+ * when no id_token is available. `post_logout_redirect_uri` returns the
+ * browser to the app afterwards.
+ */
+function buildKeycloakLogoutUrl(
+  publicUrl: string,
+  clientId: string,
+  returnUrl: string,
+  idToken?: string | null,
+): string {
+  const params = new URLSearchParams({
+    post_logout_redirect_uri: returnUrl,
+    client_id: clientId,
+  });
+  if (idToken) params.set("id_token_hint", idToken);
+  return `${publicUrl}/protocol/openid-connect/logout?${params.toString()}`;
+}
+
+/**
+ * Performs a Keycloak RP-initiated logout.
+ *
+ * IMPORTANT: the Keycloak end-session URL must NOT be passed as
+ * `signOut({ callbackUrl })`. NextAuth v4's default `redirect` callback
+ * rejects cross-origin callback URLs and falls back to the app base URL, so
+ * the browser never reaches Keycloak and the SSO cookie survives — causing
+ * the next sign-in to silently restore the previous user (issue #52).
+ *
+ * Correct flow: clear the NextAuth session with `signOut({ redirect: false })`,
+ * then hard-redirect the browser to Keycloak's end-session endpoint.
+ */
+function keycloakLogout(logoutUrl: string): void {
+  signOut({ redirect: false }).then(() => {
+    window.location.href = logoutUrl;
+  });
+}
+
+/**
  * Switch to a different Keycloak user.
  * Must sign out from BOTH NextAuth AND Keycloak itself — otherwise Keycloak's
  * SSO session cookie auto-authenticates the same user on the next signIn().
@@ -91,6 +131,7 @@ function switchPersona(
   _personaId: string,
   onClose: () => void,
   keycloakConfig: { publicUrl: string; clientId: string } | null,
+  idToken?: string | null,
 ) {
   onClose();
   // Fall back to same-origin "/" if the runtime config hasn't loaded yet —
@@ -113,18 +154,23 @@ function switchPersona(
   // Sign out from NextAuth first, then redirect to Keycloak's logout endpoint.
   // The post_logout_redirect_uri sends the user to /auth/switch which triggers
   // a new sign-in with login_hint.
-  signOut({ redirect: false }).then(() => {
-    const returnUrl = window.location.origin + "/auth/switch";
-    const logoutUrl = `${keycloakPublicUrl}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURIComponent(
-      returnUrl,
-    )}&client_id=${clientId}`;
-    window.location.href = logoutUrl;
-  });
+  const returnUrl = window.location.origin + "/auth/switch";
+  keycloakLogout(
+    buildKeycloakLogoutUrl(keycloakPublicUrl, clientId, returnUrl, idToken),
+  );
 }
 
 export default function UserMenu() {
   // Tab-scoped session: immune to cross-tab cookie changes in live mode.
-  const { session: tabSession, status: tabStatus } = useTabSession();
+  const {
+    session: tabSession,
+    status: tabStatus,
+    liveSession,
+  } = useTabSession();
+  // id_token from the live NextAuth session — passed to Keycloak's
+  // end-session endpoint as id_token_hint so logout skips the confirm prompt.
+  const idToken =
+    (liveSession as { idToken?: string } | null | undefined)?.idToken ?? null;
   // Always call useDemoPersona — hook rules require unconditional calls.
   const demoPersona = useDemoPersona();
   const demoSession =
@@ -453,6 +499,7 @@ export default function UserMenu() {
                           persona.personaId,
                           () => setOpen(false),
                           keycloakConfig,
+                          idToken,
                         );
                       }
                     }}
@@ -504,14 +551,26 @@ export default function UserMenu() {
                   clearDemoPersona();
                   return;
                 }
-                const logoutUrl = keycloakConfig?.publicUrl
-                  ? `${
-                      keycloakConfig.publicUrl
-                    }/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURIComponent(
+                // Sign out of Keycloak's SSO session too — not just the
+                // NextAuth app cookie. Passing the Keycloak end-session URL
+                // as signOut({ callbackUrl }) does NOT work: NextAuth drops
+                // cross-origin callback URLs, so the browser never reaches
+                // Keycloak and the SSO cookie survives — the next sign-in
+                // then silently restores this same user (issue #52).
+                if (keycloakConfig?.publicUrl) {
+                  keycloakLogout(
+                    buildKeycloakLogoutUrl(
+                      keycloakConfig.publicUrl,
+                      keycloakConfig.clientId,
                       window.location.origin,
-                    )}&client_id=${keycloakConfig.clientId}`
-                  : undefined;
-                signOut({ callbackUrl: logoutUrl ?? "/" });
+                      idToken,
+                    ),
+                  );
+                } else {
+                  // Runtime config not loaded — fall back to NextAuth-only
+                  // sign-out (Keycloak SSO cookie cannot be cleared here).
+                  signOut({ callbackUrl: "/" });
+                }
               }}
               className="flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-[var(--surface-2)] rounded transition-colors"
             >

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -103,6 +103,10 @@ export const authOptions: NextAuthOptions = {
       if (account && profile) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token;
+        // Persist the id_token so the client can pass it as `id_token_hint`
+        // to Keycloak's end-session endpoint on sign-out. Without it Keycloak
+        // shows a logout-confirmation prompt instead of logging out directly.
+        token.idToken = account.id_token;
         const keycloakProfile = profile as Record<string, unknown>;
         const roles = extractRealmRoles(keycloakProfile, account);
         // Store the Keycloak login name (preferred_username) for derivation.
@@ -126,6 +130,7 @@ export const authOptions: NextAuthOptions = {
       return {
         ...session,
         accessToken: token.accessToken as string,
+        idToken: token.idToken as string,
         roles: (token.roles as string[]) ?? [],
         user: {
           ...session.user,

--- a/ui/src/types/next-auth.d.ts
+++ b/ui/src/types/next-auth.d.ts
@@ -6,6 +6,8 @@ import { JWT } from "next-auth/jwt";
 declare module "next-auth" {
   interface Session extends DefaultSession {
     accessToken?: string;
+    /** Keycloak id_token — used as id_token_hint on RP-initiated logout. */
+    idToken?: string;
     roles: string[];
     user: {
       id: string;
@@ -24,6 +26,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     accessToken?: string;
     refreshToken?: string;
+    idToken?: string;
     roles?: string[];
   }
 }


### PR DESCRIPTION
## Summary

Fixes #52 — signing out then signing in again silently restored the **previous** user. The only workaround was a fresh incognito window per user.

## Root cause

The **Sign out** button in `UserMenu.tsx` called `signOut({ callbackUrl: logoutUrl })` where `logoutUrl` is Keycloak's **cross-origin** end-session URL. NextAuth v4's default `redirect` callback rejects cross-origin callback URLs and falls back to the app base URL — so the browser **never reached Keycloak**. The NextAuth app cookie was cleared, but Keycloak's SSO cookies (`KEYCLOAK_IDENTITY` / `KEYCLOAK_SESSION`) survived. The next `signIn("keycloak")` was then silently re-authenticated as the same user with no login form.

Incognito worked because it carries no Keycloak SSO cookie.

`switchPersona` in the same file already handled this correctly (`signOut({ redirect: false })` → hard browser redirect); only the plain Sign out button was broken.

## Fix

- Sign out of NextAuth with `signOut({ redirect: false })`, then hard-redirect the browser (`window.location.href`) to Keycloak's end-session endpoint. Extracted into shared `keycloakLogout` / `buildKeycloakLogoutUrl` helpers used by both sign-out and `switchPersona`.
- Persist the Keycloak `id_token` on the JWT and expose it on the session, so the end-session URL can pass `id_token_hint` — Keycloak then logs out without a confirmation prompt.

## Tests

- **`UserMenu.test.tsx` regression test** — asserts `signOut` is called with `{ redirect: false }` (never the cross-origin URL as `callbackUrl`) and the browser is hard-redirected to the end-session endpoint. **Verified to fail against the pre-fix code** (it received `callbackUrl: https://keycloak.../openid-connect/logout`).
- **`auth-callbacks.test.ts`** — `id_token` persisted on the JWT and exposed on the session.
- **New E2E journey 35** (`35-logout-session-clearing.spec.ts`, J820–J822) — logout fully clears the session and a *different* user can sign in afterwards without an incognito window. Skips automatically when Keycloak is unreachable.

All 99 unit-test files / 1697 tests pass; `tsc` and ESLint clean (55 warnings = baseline, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)