### PR TITLE
fix(finops): scale the EDC stack off-hours — close ADR-024/023 cost gap

### DIFF
--- a/.github/workflows/aca-schedule.yml
+++ b/.github/workflows/aca-schedule.yml
@@ -1,12 +1,18 @@
 name: ACA Off-Hours Scale (Mon-Fri 07-20 Europe/Berlin)
 
-# ADR-022: re-enable the schedule for cost optimisation. INF-STG-EU_EHDS no
-# longer requires 24/7 (the public ehds.mabu.red demo is documented as a
-# weekday-hours service in the README). Stop saves ~€100-150/mo on the
-# unlimited subscription by halting the always-on apps overnight + weekends.
+# ADR-022/023: re-enable the off-hours schedule for cost optimisation.
+# ADR-027: extend it to the full EDC stack. ADR-024 provisioned the 8 EDC
+# apps at min=1 (24/7) but this schedule still only covered the 7 "healthy"
+# apps — so the EDC stack billed nights + weekends, the cost surge flagged by
+# FinOps in May 2026. The schedule now scales all 15 Container Apps.
+#
+# INF-STG-EU_EHDS no longer requires 24/7 — the public ehds.mabu.red demo is
+# documented as a weekday-hours service in the README, so off-hours
+# scale-down is non-disruptive. Stop saves ~€250-300/mo by halting every app
+# overnight + weekends (apps run ~65h/week instead of 168h).
 #
 # The schedule was originally introduced by ADR-016 and disabled by ADR-018
-# when the subscription changed; ADR-022 reinstates it under the
+# when the subscription changed; ADR-022/023 reinstated it under the
 # Workaround-B (Postgres-on-ACA) model: there's no Microsoft.DBforPostgreSQL
 # Flexible Server to start/stop, so postgres scale-to-0 is a Container App
 # update like everything else.
@@ -75,12 +81,13 @@ jobs:
 
       - name: Scale all Container Apps to 0
         run: |
-          # Apps that were already scaled to 0 by ADR-022 (broken EDC services)
-          # are intentionally NOT in this list — they're either flagged for
-          # deletion or tracked under issue #25; the schedule shouldn't ever
-          # restore them to min=1.
-          # Postgres is included because Workaround B (ADR-018) made it an
-          # ACA app rather than a Flexible Server.
+          # All 15 Container Apps are scaled to 0 off-hours (ADR-027).
+          #  - 7 core apps: postgres, neo4j, keycloak, vault, proxy, ui,
+          #    catalog-enricher. Postgres is included because Workaround B
+          #    (ADR-018) made it an ACA app, not a Flexible Server.
+          #  - 8 EDC apps: ADR-024 provisioned the full EDC stack at min=1.
+          #    ADR-027 adds them here so they no longer bill nights + weekends.
+          # Stop order is irrelevant; start order is not (see the start job).
           APPS=(
             mvhd-postgres
             mvhd-neo4j
@@ -89,6 +96,14 @@ jobs:
             mvhd-neo4j-proxy
             mvhd-ui
             mvhd-catalog-enricher
+            mvhd-nats
+            mvhd-controlplane
+            mvhd-dp-fhir
+            mvhd-dp-omop
+            mvhd-identityhub
+            mvhd-issuerservice
+            mvhd-tenant-mgr
+            mvhd-provision-mgr
           )
           echo "=== Scaling ${#APPS[@]} Container Apps to 0 replicas ==="
           for app in "${APPS[@]}"; do
@@ -105,7 +120,7 @@ jobs:
           echo "## Off-Hours Scale-Down" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Time:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Status:** 7 healthy Container Apps (incl. mvhd-postgres) scaled to 0" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Status:** 15 Container Apps (7 core + 8 EDC) scaled to 0" >> "$GITHUB_STEP_SUMMARY"
           echo "**Next start:** Monday-Friday 05:00 UTC (07:00 Europe/Berlin CEST)" >> "$GITHUB_STEP_SUMMARY"
 
   start:
@@ -159,15 +174,39 @@ jobs:
             --name mvhd-ui --resource-group "$RESOURCE_GROUP" \
             --min-replicas 1 --max-replicas 3 \
             -o none || echo "::warning::Failed to scale mvhd-ui"
-          # NOTE: mvhd-controlplane / -dp-fhir / -dp-omop / -identityhub /
-          # -issuerservice / -tenant-mgr / -provision-mgr / -nats remain at
-          # 0/1 — they don't boot on ACA today (issue #25 / ADR-022). Do not
-          # restore them here.
+          # NATS — started here with the core apps so JetStream is ready
+          # before the EDC controlplane comes up in the next step.
+          echo "  mvhd-nats -> 1/1"
+          az containerapp update \
+            --name mvhd-nats --resource-group "$RESOURCE_GROUP" \
+            --min-replicas 1 --max-replicas 1 \
+            -o none || echo "::warning::Failed to scale mvhd-nats"
+          # The 7 remaining EDC apps (controlplane, data planes, identity hub,
+          # issuer service, CFM tenant/provision managers) are restored after
+          # the stateful wait below — see "Restore EDC stack" (ADR-024/027).
 
       - name: Wait for stateful services to be reachable
         run: |
           echo "Waiting 75s for Neo4j + Vault pods to start..."
           sleep 75
+
+      - name: Restore EDC stack (ADR-024)
+        run: |
+          # ADR-024 provisions the full EDC stack at min=1 during work hours;
+          # ADR-027 scales it to 0 off-hours. Postgres (started first) and
+          # NATS (started with the core apps) are reachable by now. The
+          # controlplane needs both; the data planes, identity hub, issuer
+          # service and CFM managers need Postgres.
+          echo "=== Restoring 7 EDC Container Apps to 1/1 ==="
+          for app in mvhd-controlplane mvhd-dp-fhir mvhd-dp-omop \
+                     mvhd-identityhub mvhd-issuerservice \
+                     mvhd-tenant-mgr mvhd-provision-mgr; do
+            echo "  $app -> 1/1"
+            az containerapp update \
+              --name "$app" --resource-group "$RESOURCE_GROUP" \
+              --min-replicas 1 --max-replicas 1 \
+              -o none || echo "::warning::Failed to scale $app"
+          done
 
       - name: Re-bootstrap Vault (in-memory gotcha #1)
         run: |
@@ -207,5 +246,5 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Time:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
           echo "**Target:** ${{ steps.verify.outputs.ui_url }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Status:** PostgreSQL started, 13 Container Apps scaled up, Vault re-bootstrapped (Neo4j data persists via Azure Files — see ADR-017)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Status:** PostgreSQL started, 15 Container Apps scaled up (7 core + 8 EDC), Vault re-bootstrapped (Neo4j data persists via Azure Files — see ADR-017)" >> "$GITHUB_STEP_SUMMARY"
           echo "**Next stop:** Today 18:00 UTC (20:00 Europe/Berlin CEST)" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ADRs/ADR-027-edc-stack-off-hours-scaledown.md
+++ b/docs/ADRs/ADR-027-edc-stack-off-hours-scaledown.md
@@ -1,0 +1,94 @@
+# ADR-027: EDC Stack in Off-Hours Scale-Down (FinOps Cost Correction)
+
+**Status:** Accepted
+**Date:** 2026-05-18
+**Relates to:** [ADR-016](ADR-016-aca-off-hours-scaledown.md), [ADR-022](ADR-022-edc-connector-cost-vs-function.md), [ADR-023](ADR-023-reinstate-off-hours-scaledown.md), [ADR-024](ADR-024-full-edc-provisioning-per-participant.md)
+**Tracking:** FinOps cost review on subscription `INF-STG-EU_EHDS` (DISIT Cloud Team, May 2026)
+
+## Context
+
+The DISIT Cloud Team's FinOps review flagged a cost surge on `INF-STG-EU_EHDS`
+in May 2026 — Container Apps (`microsoft.app/containerapps`) running above the
+April daily average.
+
+Root cause: a **gap between two ADRs**.
+
+- **ADR-023** reinstated the off-hours scale-down cron (`aca-schedule.yml`).
+  At that time (2026-05-01) the EDC apps were at `min=0` per ADR-022 Option C,
+  so the schedule only managed the **7 "healthy" apps**. Its code carried a
+  `NOTE` explicitly excluding the 8 EDC apps ("they don't boot on ACA today").
+- **ADR-024** (2026-05-04) superseded ADR-022 Option C and provisioned the
+  **full EDC stack at `min=1`** via `scripts/azure/04-edc-services.sh`
+  (`--min-replicas 1 --max-replicas 1` for controlplane, dp-fhir, dp-omop,
+  identityhub, issuerservice, tenant-mgr, provision-mgr, nats).
+
+ADR-024's own cost section assumed the result would be **~€100-130/mo**
+*"combined with off-hours scale-down (ADR-016, ADR-023)"*. But the schedule
+was never updated to include the EDC apps. The 8 EDC apps therefore ran
+**24/7** — billing through every night and weekend — instead of weekday
+hours. ADR-022 estimated the full EDC stack at `min=1` costs **~€252-272/mo**;
+left 24/7, roughly **60% of that (~€150-165/mo)** was spent on hours when
+nobody uses the `ehds.mabu.red` demo.
+
+## Decision
+
+**Extend `aca-schedule.yml` to scale the 8 EDC apps with the rest of the
+stack** — restoring the cost envelope ADR-024 assumed.
+
+The schedule now manages **all 15 Container Apps**:
+
+| Group         | Apps                                                                                          | Work-hours scale |
+| ------------- | --------------------------------------------------------------------------------------------- | ---------------- |
+| Core (7)      | postgres, neo4j, keycloak, vault, neo4j-proxy, ui, catalog-enricher                           | 1/1 (proxy 1/2, ui 1/3) |
+| EDC stack (8) | nats, controlplane, dp-fhir, dp-omop, identityhub, issuerservice, tenant-mgr, provision-mgr   | 1/1              |
+
+Off-hours (nightly 20:00 Europe/Berlin + all weekend) every app is scaled to
+`0/0`. The operating window is unchanged: **Mon-Fri 07:00-20:00 Europe/Berlin**,
+the weekday-hours service already documented in the README.
+
+### Start ordering
+
+EDC apps have boot-time dependencies, so the start job is sequenced:
+
+1. **Postgres** first (+20 s) — controlplane, identityhub, issuerservice and
+   the data planes all use Postgres datasources.
+2. **NATS** with the core apps — JetStream must be ready before the
+   controlplane subscriber starts.
+3. 75 s stateful wait (Neo4j + Vault).
+4. **Restore EDC stack** — the 7 remaining EDC apps to `1/1`.
+
+Stop ordering is irrelevant — all apps scale to `0/0` in any order.
+
+## Consequences
+
+### Positive
+
+- EDC apps run **~65 h/week instead of 168 h/week** (≈61 % less runtime).
+- Total subscription scale-down saving rises to **~€250-300/mo**; the realised
+  monthly figure converges on ADR-024's intended **~€100-130/mo**.
+- No loss of function: the demo's operating window is unchanged, and protocol
+  compliance (`/compliance/tck`) is still observable during weekday hours.
+
+### Negative / accepted
+
+- Weekday morning cold-start grows by one step (~1-2 min) for the EDC restore.
+- If an EDC app crash-loops, it is now also restarted by the morning cron —
+  acceptable, and made visible in `/admin/components`.
+
+### Neutral
+
+- The schedule still uses workflow-dispatch SP credentials (memory:
+  `project_aca_job_write_via_ci`) — no new permissions required.
+
+## Rollback
+
+Revert the `aca-schedule.yml` change. The EDC apps return to 24/7 `min=1`
+(ADR-024 baseline). One-line, no data impact — scale-to-zero is non-destructive
+(Postgres + Neo4j persist on Azure Files, ADR-017).
+
+## References
+
+- ADR-024 — Full EDC Provisioning per Participant (the `min=1` decision)
+- ADR-023 — Reinstate Off-Hours ACA Scale-Down (the schedule)
+- ADR-022 — EDC Connector cost analysis (~€252-272/mo for the full stack)
+- `.github/workflows/aca-schedule.yml` — the implementation

--- a/docs/planning-health-dataspace-v2.md
+++ b/docs/planning-health-dataspace-v2.md
@@ -133,5 +133,6 @@ All three core specifications are now final or near-final:
 | [024](ADRs/ADR-024-full-edc-provisioning-per-participant.md) | Full EDC Provisioning per Participant on Azure | 2026-05-04 | Accepted   |
 | [025](ADRs/ADR-025-keycloak-custom-domain.md)                | Keycloak Custom Domain (auth.ehds.mabu.red)    | 2026-05-10 | Accepted   |
 | [026](ADRs/ADR-026-token-efficient-planning-structure.md)    | Token-Efficient Planning & ADR Structure       | 2026-05-17 | Accepted   |
+| [027](ADRs/ADR-027-edc-stack-off-hours-scaledown.md)         | EDC Stack in Off-Hours Scale-Down (FinOps)     | 2026-05-18 | Accepted   |
 
 > **Note:** The full text of ADR-1 through ADR-9 has been moved into the standalone ADR documents linked in the table above. Click any row to read the full context, decision, and consequences.


### PR DESCRIPTION
## Summary

Addresses the May 2026 Container Apps cost surge on subscription `INF-STG-EU_EHDS` flagged by the DISIT Cloud Team FinOps review.

## Root cause

A gap between two ADRs:

- **ADR-023** reinstated the off-hours scale-down cron (`aca-schedule.yml`) while the 8 EDC apps were at `min=0` (ADR-022 Option C). The schedule managed only the **7 core apps** and carried a `NOTE` explicitly excluding the EDC stack.
- **ADR-024** (2026-05-04) then provisioned the **full EDC stack at `min=1`** via `scripts/azure/04-edc-services.sh`.

The schedule was never updated. So the 8 EDC apps (`controlplane`, `dp-fhir`, `dp-omop`, `identityhub`, `issuerservice`, `tenant-mgr`, `provision-mgr`, `nats`) ran **24/7** — ADR-022 estimated the full EDC stack at ~€252-272/mo, and ~60% of that billed for nights/weekends. ADR-024's own cost section had assumed these apps were covered by the schedule (target ~€100-130/mo).

## Fix — ADR-027

`aca-schedule.yml` now scales **all 15 Container Apps** (7 core + 8 EDC):

- **Stop** — all 15 → `0/0` nightly 20:00 Europe/Berlin + all weekend.
- **Start** — Postgres first (+20s), NATS with the core apps (JetStream ready before the controlplane), then the 7 remaining EDC apps after the 75s stateful wait — sequenced for EDC boot-time dependencies on Postgres + NATS.
- Operating window unchanged: **Mon-Fri 07:00-20:00 Europe/Berlin** (the weekday-hours service already documented in the README).

## Expected effect

EDC apps run **~65 h/week instead of 168 h** (≈61% less runtime). Total scale-down saving rises to **~€250-300/mo**; realised monthly cost converges on ADR-024's intended **~€100-130/mo**. No loss of function — protocol compliance stays observable during weekday hours.

## Files

- `.github/workflows/aca-schedule.yml` — schedule covers the EDC stack
- `docs/ADRs/ADR-027-edc-stack-off-hours-scaledown.md` — new ADR
- `docs/planning-health-dataspace-v2.md` — ADR index row

## Verification

YAML validated. The schedule's effect is realised on the next cron tick (stop 18:00 UTC / start 05:00 UTC Mon-Fri). Can also be exercised now via `workflow_dispatch` (`stop` / `start`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)