### PR TITLE
docs(sdlc): SDLC + deterministic agentic-AI guidelines (#55)

### DIFF
--- a/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
+++ b/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
@@ -1,0 +1,293 @@
+# Deterministic Agentic AI Development with Claude Code
+
+**Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
+**Audience:** anyone asking _"how do you actually use Agentic AI for programming
+without it going off the rails?"_
+**Last updated:** 2026-05-31 · **Maintainer:** Matthias (`@ma3u`)
+
+> Companion document: **[Software Development Life Cycle
+> (SDLC)](./SDLC.md)** — the deterministic gates this AI author has to pass
+> through, same as any human contributor.
+
+---
+
+## 1. The thesis: wrap a non-deterministic author in a deterministic harness
+
+Large Language Models are **non-deterministic**. Ask the same question twice and
+you may get two different answers. Software, by contrast, demands
+**determinism** — the build is reproducible, the tests are reproducible, the
+deployment is reproducible.
+
+The whole craft of "agentic AI for programming" is bridging that gap:
+
+> **Treat the agent as a fast, tireless, broadly-knowledgeable junior developer.
+> Then make every piece of its output pass the _same deterministic gates_ a
+> senior would enforce — automatically, every time.**
+
+The agent supplies _breadth and speed_. The harness supplies _determinism and
+trust_. Neither is sufficient alone. This document describes the harness I use
+with [Claude Code](https://claude.com/claude-code) on this project, and the rules
+of engagement that keep AI-generated code reviewable and safe in a
+regulated-health-data domain.
+
+The guiding principle, borrowed from how I run human teams:
+**Evidence > assumptions · Code > documentation · The gate, not the author,
+decides what ships.**
+
+---
+
+## 2. The determinism stack
+
+Determinism is layered. Each layer narrows what the agent _can_ do and sharpens
+what it _should_ do, so that by the time code reaches the deterministic gates it
+is already shaped by the project's rules.
+
+```mermaid
+flowchart TD
+    L0["L0 · Spec — CLAUDE.md + .claude/rules/*\n(single source of truth, read every session)"]
+    L1["L1 · Constrained tools — settings.json allow-list\n(safe ops auto-run, the rest needs approval)"]
+    L2["L2 · Durable memory — ADRs + planning index\n(why decisions were made)"]
+    L3["L3 · Repeatable prompts — slash commands\n(/review, /fix-issue, /deploy-check)"]
+    L4["L4 · Specialist sub-agents — architect, compliance,\ntester, security (read-only, scoped)"]
+    L5["L5 · Skills — domain packs (health-dataspace)"]
+    L6["L6 · Deterministic gates — pre-commit + CI/CD\n(the SAME gates a human passes)"]
+    L0 --> L1 --> L2 --> L3 --> L4 --> L5 --> L6
+```
+
+The bottom layer (L6) is shared with humans and is documented in the
+[SDLC](./SDLC.md). The layers above it are the _agentic_ scaffolding and are the
+subject of this document.
+
+---
+
+## 3. Anatomy of the `.claude/` folder
+
+Everything that constrains and configures the agent is **checked into the repo**,
+so it is versioned, reviewable, and identical for every session and every
+contributor.
+
+| Path                               | Role                                                                                                                                                                                                                                         |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLAUDE.md` (repo root)            | The operating manual the agent reads **every session**: build commands, the 5-layer architecture, key directories, coding conventions, and the **Top Gotchas** (the traps that waste an hour if you don't know them). Kept short on purpose. |
+| `.claude/settings.json`            | **Permission allow-list** — which tool calls run without asking (see §4).                                                                                                                                                                    |
+| `.claude/rules/code-style.md`      | TypeScript/Next.js + Cypher + Bash + Prettier conventions, scoped to source paths.                                                                                                                                                           |
+| `.claude/rules/testing.md`         | Test frameworks, locations, commands, what _not_ to mock.                                                                                                                                                                                    |
+| `.claude/rules/api-conventions.md` | Protocols (DSP/DCP/FHIR/OMOP/EHDS/GDPR), data models, route patterns, role/access matrix, mock-fixture mapping.                                                                                                                              |
+| `.claude/commands/*.md`            | **Slash commands** — repeatable, parameterised prompts (§5).                                                                                                                                                                                 |
+| `.claude/agents/*.md`              | **Specialist sub-agents** — scoped, read-only experts (§6).                                                                                                                                                                                  |
+| `.claude/skills/SKILL.md`          | A domain **skill** pack auto-triggered by task type.                                                                                                                                                                                         |
+
+Because this lives in git, improving the agent is a normal PR: change a rule,
+review the diff, merge. The agent's behaviour is **configuration, not folklore**.
+
+---
+
+## 4. Constrained tools & permissions (blast-radius control)
+
+`.claude/settings.json` is an **allow-list**. Read-only and obviously-safe
+operations run without interrupting the flow; everything else requires explicit
+approval:
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(npm run build:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(npx tsc:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}
+```
+
+The agent can freely **inspect, build, type-check, and test** — the actions you
+_want_ it doing constantly. Anything that mutates outside the working tree
+(pushing, deleting, deploying, installing) surfaces for a human decision. This is
+the "least privilege" principle applied to an AI author.
+
+---
+
+## 5. Repeatable prompts: slash commands
+
+A free-form prompt is non-deterministic by nature. A **slash command** is a
+checked-in, version-controlled prompt that produces a _consistent workflow_ every
+time it's invoked — the determinism trick applied to the instruction itself.
+
+| Command          | What it does                                                                                                                                                                                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/review`        | Reviews the working `git diff` against this project's conventions: TS strict mode + `@/*` imports, Cypher `MERGE`-only + PascalCase labels, **fictional org names only**, mock fixtures kept in sync with API routes, tests for new behaviour. |
+| `/fix-issue <N>` | Investigates a GitHub Issue end-to-end: `gh issue view N` → locate relevant files → implement → verify.                                                                                                                                        |
+| `/deploy-check`  | Pre-deployment validation using the project's real build/test commands.                                                                                                                                                                        |
+
+These encode "the way we do X here" once, so the _quality of the prompt_ no
+longer depends on how I phrased it that day.
+
+---
+
+## 6. Specialist sub-agents (scoped, read-only experts)
+
+For deep reasoning in one domain, the project ships **specialist sub-agents**
+under `.claude/agents/`. Each is deliberately constrained:
+
+| Agent                   | When to use it                                                                                                        | Model  | Tools                                |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------ |
+| **architect**           | Reason about the 5-layer Neo4j graph, DSP/FHIR/OMOP/DCAT-AP interactions, service topology, cross-cutting trade-offs. | Sonnet | `Read, Grep, Glob, Bash` (read-only) |
+| **compliance-reviewer** | Verify EHDS conformance, DSP/DCP protocol correctness, GDPR patient-rights, audit-trail integrity.                    | Sonnet | read-only                            |
+| **tester**              | Audit coverage, triage test failures, plan new Playwright journeys, assess Vitest health.                             | Sonnet | read-only                            |
+| **security**            | Review auth flows, RBAC, Keycloak config, credential/secret handling, vulnerabilities.                                | Sonnet | read-only                            |
+
+Two deliberate constraints make these safe:
+
+1. **Read-only toolset.** They reason and advise; they don't write. (The
+   architect agent's brief literally says _"Do not write code unless explicitly
+   asked; your job is to reason and advise."_) A wrong opinion is cheap; a wrong
+   edit is not.
+2. **Sonnet, not the top model.** Right-sized for focused, scoped review — fast
+   and economical, with the orchestrating session retaining the harder
+   reasoning.
+
+This mirrors a real team: you bring in a security or compliance reviewer to _look
+and advise_, not to silently rewrite your branch.
+
+---
+
+## 7. Rules of engagement (the determinism techniques)
+
+These are the habits — encoded in `CLAUDE.md` and the rules files — that keep
+agent output predictable and trustworthy:
+
+- **Read before write.** Always inspect a file before editing it. No blind edits.
+- **Idempotent by default.** Cypher uses `MERGE`, never bare `CREATE`; schema
+  constraints use `IF NOT EXISTS`. Re-running a change is a no-op, not a
+  duplication — so a retried or repeated agent action is safe.
+- **Plan / ADR first for big changes.** Architectural work starts with an ADR
+  (see [SDLC §3](./SDLC.md#3-plan-before-you-build-issues-adrs-and-a-token-efficient-plan)),
+  so the _decision_ is reviewed before a single line is written.
+- **Token-efficient context** ([ADR-026](./ADRs/ADR-026-token-efficient-planning-structure.md)).
+  Routinely-loaded docs are kept under **~15K tokens**. A sharp, relevant context
+  produces sharper reasoning — load the ADR _index_ then the one relevant ADR,
+  not the whole corpus.
+- **Evidence over assertion.** A change isn't "done" because the agent says so —
+  it's done when the **gates are green** (lint, type-check, tests, scans). The
+  [SDLC](./SDLC.md) gates apply to AI commits identically to human commits.
+- **Traceable provenance.** AI-assisted commits carry a `Co-Authored-By: Claude`
+  trailer, so `git log` always shows what the agent touched — essential for audit
+  in a health-data context.
+- **Domain guardrails.** Hard rules the agent must never break — e.g. **only
+  fictional organisation names** in demo data and docs (AlphaKlinik Berlin,
+  PharmaCo Research AG, …; never real entities). These live in the rules files
+  and are checked by `/review`.
+
+---
+
+## 8. The human-in-the-loop: the conceptual-review flywheel
+
+The most important part of agentic development is **not** the AI — it's the
+**feedback loop** that turns human expertise into better specifications.
+
+```mermaid
+flowchart LR
+    H["Human expert\n(architecture · governance · domain)"] -->|"sharper spec:\nIssue / ADR / corrected doc"| S["Spec\nCLAUDE.md · ADRs · rules"]
+    S -->|"read every session"| A["Claude Code\nproposes change"]
+    A -->|"PR"| G["Deterministic gates\n(SDLC)"]
+    G -->|"merged result"| R["Running system + docs"]
+    R -->|"review & critique"| H
+```
+
+An AI agent is only as good as the spec it reads. When a human corrects a
+sequence diagram, tightens an ADR, or files a precise Issue, that correction
+becomes **durable input** the agent honours in _every_ subsequent session. So the
+highest-leverage contribution to this project is often **conceptual, not
+code**: better requirements, clearer governance rules, corrected architecture
+descriptions. Each one raises the floor of everything the AI produces next.
+
+This is the answer to _"how to best use Agentic AI for programming"_: don't aim
+for a hands-off autopilot. Aim for a **tight loop** where human judgement
+continuously sharpens the spec, and deterministic tooling continuously verifies
+the output.
+
+---
+
+## 9. Strengths, risks, and mitigations (an honest assessment)
+
+| Where agentic AI excels here                                              | Where it needs the harness                             | Mitigation in this project                                                                                 |
+| ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Breadth — wiring CI, security scanners, SBOM, multi-layer schemas quickly | **Confidently wrong** output (plausible but incorrect) | Deterministic gates (tests, type-check, scans); `/review`; read-only specialist sub-agents                 |
+| Consistency — applies project conventions uniformly                       | **Drift from intent** over a long task                 | ADR-first for big changes; small PRs; human review of the diff                                             |
+| Speed — repetitive refactors, fixtures, boilerplate                       | **Hallucinated APIs / fabricated facts**               | "Base everything strictly on the repo, don't invent" (the init recipe, §10); CI catches non-existent calls |
+| Tireless — never skips a checklist step                                   | **Over-engineering / scope creep**                     | KISS/YAGNI in the rules; maintainer trims scope at PR                                                      |
+| Great at scaffolding tedious safety work                                  | **Blast radius** if given broad tools                  | Permission allow-list; least-privilege tools (§4)                                                          |
+
+The pattern: **AI handles the breadth; deterministic tooling and human judgement
+handle the correctness.**
+
+---
+
+## 10. The init recipe — bootstrapping Claude Code on any repo
+
+The `.claude/` setup above wasn't hand-written from scratch — it was generated by
+pointing Claude Code at the existing repo with a single, carefully-bounded
+instruction, then reviewed like any other change. The reusable recipe is
+published as a gist:
+
+**→ [ClaudeCodeInit — the bootstrap prompt](https://gist.github.com/ma3u/09e76d3b604d132673bc4a59b092709a)**
+
+In summary, it asks the agent to _read all planning and architecture docs in the
+repo_ and generate a complete `.claude/` folder:
+
+1. **`CLAUDE.md`** — concise: build commands, architecture, key dirs,
+   conventions, top project-specific gotchas.
+2. **`settings.json`** — allow safe ops (build/test/git-read/grep/find), require
+   approval for destructive actions.
+3. **`code-style.md`** — conventions extracted from the _actual_ codebase.
+4. **`testing.md`** — real test frameworks, commands, standards.
+5. **`api-conventions.md`** — protocols, data models, API patterns.
+6. **`review.md`** — a code-review command using `git diff` injection.
+7. **`fix-issue.md`** — an Issue-investigation workflow with `gh` CLI.
+8. **`deploy-check.md`** — pre-deploy validation using the real build command.
+9. **`SKILL.md`** — domain skill packs, auto-triggered by task type.
+10. **`agents/`** — specialist read-only agents (architect, compliance, tester,
+    security) on Sonnet.
+
+The one constraint that makes it trustworthy:
+
+> **"Base all content strictly on what you find in this repository. Do not invent
+> architecture or conventions not present in the code or docs."**
+
+That single rule is what turns a generic AI into a _project-specific_ one — and
+it's the same anti-hallucination discipline that runs through everything above.
+
+---
+
+## 11. Outlook — maturing the agentic setup
+
+1. **Claude in CI** — automated PR review via the Claude GitHub app/Action, so
+   every PR gets an AI first-pass review on the server, not just locally.
+2. **Branch protection** (see [SDLC §11](./SDLC.md#11-outlook--next-steps)) so
+   even AI commits cannot bypass green CI.
+3. **Commit-message enforcement** (`commitlint`) so AI-authored commits keep the
+   Conventional-Commit shape that drives release notes.
+4. **Live context via MCP** — Model Context Protocol servers exposing Neo4j /
+   FHIR so the agent can reason against _current_ data, not just the schema.
+5. **An eval / regression harness for agent output** — golden tasks the setup is
+   re-run against when `CLAUDE.md` or the rules change, so configuration changes
+   are themselves tested.
+
+---
+
+## References
+
+- `CLAUDE.md`, `.claude/settings.json`, `.claude/rules/*`, `.claude/commands/*`,
+  `.claude/agents/*`, `.claude/skills/SKILL.md` — the live configuration.
+- [ClaudeCodeInit gist](https://gist.github.com/ma3u/09e76d3b604d132673bc4a59b092709a)
+  — the bootstrap recipe.
+- [ADR-026 — Token-Efficient Planning & ADR Structure](./ADRs/ADR-026-token-efficient-planning-structure.md)
+- [ADR-008 — Testing Strategy](./ADRs/ADR-008-testing-strategy.md)
+- Companion: [Software Development Life Cycle (SDLC)](./SDLC.md)
+- [Claude Code](https://claude.com/claude-code)

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -1,0 +1,393 @@
+# Software Development Life Cycle (SDLC)
+
+**Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
+**Audience:** contributors, reviewers, and anyone curious how a one-person,
+AI-assisted project keeps a regulated-domain codebase shippable.
+**Last updated:** 2026-05-31 · **Maintainer:** Matthias (`@ma3u`)
+
+> Companion document: **[Deterministic Agentic AI Development with Claude
+> Code](./AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)** — how the AI author plugs
+> into the lifecycle described here.
+
+---
+
+## 1. Philosophy: deterministic tooling around a non-deterministic author
+
+On my day job I run an SDLC for teams of **10–30 developers**. The non-negotiable
+lesson from those teams is this:
+
+> **The author proposes; deterministic tooling disposes.**
+
+It does not matter whether the author is a senior engineer, a junior, or an AI
+agent — humans and LLMs are both _non-deterministic_. You make the _output_
+trustworthy by wrapping the author in **deterministic, repeatable, automated
+gates**: linters, type-checkers, tests, security scanners, and a CI/CD pipeline
+that runs the same way every time, for everyone.
+
+This project is currently **a team of one** (me) plus an AI pair-programmer
+([Claude Code](./AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)). So I run a
+**pragmatic, partial SDLC**: I keep every deterministic gate a large team would
+have, and I consciously collapse the _people-coordination_ ceremonies (mandatory
+peer review, sprint rituals, release boards) that only make sense with more
+people. Section 10 is explicit about what is collapsed and why, and Section 11 is
+the outlook for re-introducing the parts that will matter as soon as a second
+contributor joins.
+
+The deterministic backbone is **GitHub**: Issues, Pull Requests, GitHub Actions
+(CI/CD), GitHub Pages, GitHub Releases, and Architecture Decision Records (ADRs)
+checked into the repo.
+
+---
+
+## 2. The lifecycle at a glance
+
+```mermaid
+flowchart LR
+    A[Idea / Issue] --> B{Architectural?}
+    B -- yes --> C[Write ADR\ndocs/ADRs/ADR-NNN]
+    B -- no --> D[Short-lived branch]
+    C --> D
+    D --> E[Change\nhuman + Claude Code]
+    E --> F[Local gate\npre-commit hook]
+    F --> G[Push + open PR]
+    G --> H[CI gates\nGitHub Actions]
+    H -- green --> I[Merge to main]
+    H -- red --> E
+    I --> J[Release\nui/package.json bump → tag → GitHub Release]
+    I --> K[Deploy\nGitHub Pages + Azure Container Apps]
+    J --> K
+```
+
+Each arrow that crosses a machine boundary is **automated and reproducible**.
+The human/AI judgement lives in the _Idea → ADR → Change_ segment; everything
+downstream is deterministic.
+
+---
+
+## 3. Plan before you build: Issues, ADRs, and a token-efficient plan
+
+Before any significant change, the workflow (encoded in `CLAUDE.md`) is:
+
+1. **Check existing ADRs.** Architectural decisions live in
+   `docs/ADRs/ADR-NNN-slug.md` — **27 ADRs** today (ADR-001 … ADR-027), each a
+   short, dated, _Status / Context / Decision / Consequences_ record. You start
+   from the ADR index table, then open only the ADR(s) relevant to the task.
+2. **Consult the planning index** at `docs/planning-health-dataspace-v2.md` — a
+   slim index (issue table, phase-status summary, ADR index, links). Per-phase
+   detail lives in `docs/planning/roadmap-phases-*.md` archives.
+3. **Check GitHub Issues** for related tracking:
+   `gh issue list --repo ma3u/MinimumViableHealthDataspacev2`.
+4. **Write a new ADR** for any architectural decision, and link it in the
+   planning index's ADR table.
+
+### Why the plan is split into an index + archives
+
+This is itself an ADR — **[ADR-026: Token-Efficient Planning &
+ADR Structure](./ADRs/ADR-026-token-efficient-planning-structure.md)**. The
+planning document had grown to **72,000 tokens (288 KB)** — too large to load
+into an AI agent's context alongside working files. The rule now:
+
+> Keep any routinely-loaded document under **~15K tokens (~60 KB)**. The index
+> stays slim; detail moves into phase archives, loaded only when that phase is
+> being worked.
+
+This is a _human_ readability win and an _AI_ effectiveness win — a smaller,
+sharper context produces better reasoning. See the companion document for how
+this feeds the agent.
+
+### When to write an ADR
+
+Write one when a decision is **expensive to reverse** or **cross-cutting**:
+database split, protocol choice, deployment topology, testing strategy, cost
+trade-offs. Examples in the corpus: ADR-001 (PostgreSQL + Neo4j split), ADR-008
+(testing strategy), ADR-016/023/027 (off-hours scale-down cost decisions),
+ADR-022/024 (EDC connector cost vs. function). ADRs are the project's long-term
+memory — for humans _and_ for the AI, which reads them to stay consistent.
+
+---
+
+## 4. Branching, commits, and pull requests
+
+- **Trunk-based.** `main` is the trunk and is always deployable. Work happens on
+  **short-lived branches** and merges back via **Pull Request** (recent
+  examples: #52, #53, #54). The static demo and the Azure live demo both build
+  from `main`.
+- **Conventional Commits** with scopes. Real history:
+
+  - `fix(finops): scale the EDC stack off-hours — close ADR-024/023 cost gap (#54)`
+  - `feat(neo4j+ui): add 9th tenant — Health Dataspace Operations (EDC_ADMIN slot)`
+  - `docs(adr): ADR-026 — token-efficient planning & ADR structure`
+
+  The `type(scope): subject (#PR)` shape makes history machine-readable and
+  feeds automated release notes (Section 7).
+
+- **AI attribution.** Commits produced with the AI carry a
+  `Co-Authored-By: Claude …` trailer so the provenance of agent-assisted work is
+  always traceable in `git log` — important in a regulated domain.
+- **PRs reference Issues and ADRs.** A PR description links the Issue it closes
+  and any ADR it implements, so the _why_ is one click from the _what_.
+
+> ⚠️ Today, the Conventional-Commit format is followed by **convention, not
+> enforced** by a commit-msg hook. Enforcing it is an outlook item (Section 11).
+
+---
+
+## 5. Local quality gate — the pre-commit hook
+
+The first deterministic gate runs **on your machine, before a commit is
+created** (`.git/hooks/pre-commit`, `core.hooksPath` → `.git/hooks`). It runs
+fast checks only — the heavy suite runs in CI:
+
+| Step | Tool            | What it does                                                                             |
+| ---- | --------------- | ---------------------------------------------------------------------------------------- |
+| 1    | **Prettier**    | Auto-formats staged `*.md`, `*.yaml`, `*.json`, `*.ts(x)`, `*.js(x)` and re-stages them. |
+| 2    | **ESLint**      | Lints staged TS/TSX with `--max-warnings 55` (mirrors the CI threshold).                 |
+| 3    | **tsc**         | Type-checks the UI with `tsconfig.build.json` (strict mode, excludes tests).             |
+| 4    | **Secret scan** | Blocks obvious secret patterns (`api_key`, `token`, `private_key`, …) in staged content. |
+
+Because Prettier **re-writes and re-stages** files, a commit can require a
+`git add` + retry — that is by design, not a bug.
+
+> **Bypass policy:** `git commit --no-verify` is reserved for genuine
+> emergencies only. The CI gate (next section) re-runs the same checks, so a
+> bypass buys you nothing on `main`.
+
+The unit/integration test suite runs in CI on **every push** (Section 6); the
+documented `pre-push` hook (full Vitest run) is part of the standard and is an
+outlook item to ship to every contributor's clone uniformly (Section 11).
+
+---
+
+## 6. CI gates — GitHub Actions
+
+CI is the **authoritative, deterministic gate**. It runs the same way for every
+push and PR, independent of anyone's laptop. The pipeline is split into several
+workflows by purpose.
+
+### 6.1 Test Suite — `.github/workflows/test.yml`
+
+Triggers: **push to any branch** and **pull request to `main`** (scoped to
+`ui/**` and `services/neo4j-proxy/**` paths), plus manual dispatch.
+
+| Job                                   | Gate                                            | Runs on                  |
+| ------------------------------------- | ----------------------------------------------- | ------------------------ |
+| **UI Tests (Vitest)**                 | unit + integration + coverage                   | push & PR                |
+| **Neo4j Proxy Tests (Vitest)**        | proxy unit + coverage                           | push & PR                |
+| **Lint (ESLint)**                     | `npm run lint`                                  | push & PR                |
+| **Secret Scan (gitleaks)**            | full-history secret detection — _blocks_        | push & PR                |
+| **Dependency Audit (npm audit)**      | `--audit-level=high` (UI blocks; proxy reports) | push & PR                |
+| **SBOM (CycloneDX)**                  | software bill of materials, spec 1.5            | push & PR                |
+| **Licence Compliance**                | allow-list of OSS licences only                 | push & PR                |
+| **Trivy Security Scan**               | vuln/secret/misconfig → SARIF to Security tab   | push & PR                |
+| **Kubescape K8s Posture**             | NSA (+ CIS) framework scan of `k8s/`            | push & PR                |
+| **Performance Budget (Lighthouse)**   | Core Web Vitals budgets                         | **main / dispatch only** |
+| **E2E (Playwright)** + WCAG + pentest | browser journeys, a11y, OWASP/BSI               | **main / dispatch only** |
+
+Two deliberate design choices:
+
+- **Fast PR feedback.** The expensive jobs (Lighthouse, Playwright E2E) are
+  gated to `main`/dispatch, so a PR gets quick deterministic feedback from the
+  unit/lint/security tier. Depth runs after merge.
+- **Hard gates vs. reporting.** Unit tests, lint, and the secret scan _block_.
+  Some scanners (Trivy findings, the WCAG ratchet, the pentest suite that needs
+  live services) currently run as **report-only** (`continue-on-error`) and
+  publish to the GitHub **Security** tab / step summaries. Driving those to
+  _blocking_ is an outlook item.
+
+### 6.2 Supply-chain hardening (a concrete example)
+
+This is a regulated-domain reference implementation, so the pipeline is itself
+treated as an attack surface — a good illustration of "deterministic" meaning
+_pinned and verified_:
+
+- Security tools (gitleaks, Trivy, kubescape) are installed as **official
+  binaries pinned by version and verified by SHA-256 checksum**, not via
+  floating GitHub Actions.
+- After the **March 2026 `trivy-action` supply-chain compromise**
+  (CVE-2026-33634), the pipeline explicitly **avoids** `aquasecurity/trivy-action`
+  / `setup-trivy` and installs Trivy `0.69.3` (last clean version) directly. The
+  reasoning is documented inline in `test.yml` so the next person — or the next
+  AI session — does not silently re-introduce the compromised action.
+
+The security/compliance jobs map to recognisable controls: **BSI C5**
+(DEV-05/08, OPS-04), **OWASP** (A06), **EU CRA** Art. 13 (SBOM), and **EHDS**
+Art. 50 / SIMPL-Open.
+
+### 6.3 Protocol Compliance — `.github/workflows/compliance.yml`
+
+Triggers: **push to `main`** (on protocol-relevant paths), **weekly (Mon 06:00
+UTC)**, and manual dispatch. Runs the **DSP 2025-1 TCK**, **DCP v1.0**, and
+**EHDS domain** suites against an ephemeral JAD stack spun up in CI. These are
+report-heavy and currently `continue-on-error` — the weekly cadence catches
+protocol drift without blocking day-to-day PRs.
+
+### 6.4 GitHub Pages (static demo) — `.github/workflows/pages.yml`
+
+Triggers: **push to `main`**. This is the public demo deploy and a nice example
+of an end-to-end deterministic build:
+
+1. Spin up a **Neo4j 5** service container and **seed** it from
+   `neo4j/init-schema.cypher` + `insert-synthetic-schema-data.cypher`.
+2. Build the Next.js app, **refresh the mock JSON fixtures** from the live API
+   (`scripts/refresh-mocks.sh`) so the static fixtures match the real shapes.
+3. Run Vitest + Playwright + WCAG + pentest (report-only).
+4. **Disable API routes** (`mv src/app/api …`) and build the **static export**
+   (`NEXT_PUBLIC_STATIC_EXPORT=true`).
+5. Publish to **GitHub Pages**.
+
+> 🔑 **Gotcha:** in the static build there are _no_ server API routes — feature
+> pages fall back to `ui/public/mock/*.json`. Mock fixtures must match the live
+> API response shape exactly; CI regenerates them so they cannot drift.
+
+### 6.5 Release — `.github/workflows/release.yml`
+
+Triggers: **push to `main` that changes `ui/package.json`**. It resolves the
+version, creates the `vX.Y.Z` tag if missing, **composes release notes from the
+commit log since the previous tag**, and publishes a **GitHub Release**. It is
+idempotent (skips if the release already exists) — built specifically to stop the
+"tag pushed without a release entry" drift that bit an earlier version bump.
+
+### 6.6 Operations tier
+
+Beyond build/test, a family of workflows runs the **live Azure demo**: Azure
+Container Apps deploy, weekly demo reset (ADR-014), off-hours scale-down for cost
+(ADR-016/023/027), Keycloak custom domain, EDC participant seeding, and Bruno API
+smoke tests. They are operational automation, not part of the merge gate, but
+they follow the same principle: **every environment change is a versioned,
+re-runnable workflow**, never a manual click.
+
+---
+
+## 7. Releasing & versioning
+
+- **Source of truth:** the `version` field in `ui/package.json`.
+- **Mechanism:** bump it in a PR → on merge, the Release workflow tags
+  `vX.Y.Z` and publishes notes generated from Conventional-Commit subjects.
+- **Changelog:** derived from `git log` (which is _why_ commit hygiene matters).
+
+Moving to **fully automated version bumps** (release-please / semantic-release)
+is an outlook item — today the human decides the semver bump; the tooling does
+the tagging and publishing.
+
+---
+
+## 8. Testing strategy
+
+Codified in **[ADR-008](./ADRs/ADR-008-testing-strategy.md)** as a four-tier
+pyramid:
+
+| Tier            | Framework                     | Scope                                                                                            | When it runs                 |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------- |
+| **Unit**        | Vitest                        | pure functions, React components, API handlers mocked with `vi.mock()` — no live services, <30 s | every push (+ pre-push hook) |
+| **Integration** | Vitest + **MSW**              | API routes with mocked Neo4j responses; validates request/response shapes                        | every push                   |
+| **E2E**         | Playwright                    | full browser journeys **J001–J260** across 19 spec files                                         | `main` + dispatch            |
+| **Compliance**  | custom (DSP TCK / DCP / EHDS) | protocol conformance                                                                             | weekly + protocol changes    |
+
+Conventions (`.claude/rules/testing.md`): unit tests in `ui/__tests__/unit/`
+mirror `ui/src/`; E2E specs in `ui/__tests__/e2e/journeys/NN-*.spec.ts`; tests
+assert on visible text / aria-labels / `data-testid`, never CSS classes; do not
+mock the Neo4j driver — use the JSON fixtures under `ui/public/mock/`.
+
+> Coverage is **collected and published** on every run but **thresholds are not
+> yet enforced** (aim: critical-path coverage). Enforcing minimums is an outlook
+> item.
+
+---
+
+## 9. Environments
+
+| Environment              | How                                                                                                                     | Purpose                      |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| **Local (minimal)**      | `docker compose up -d` (Neo4j + UI)                                                                                     | day-to-day dev               |
+| **Local (full JAD)**     | `docker compose -f docker-compose.yml -f docker-compose.jad.yml up -d` + `./jad/seed-all.sh` (phases 1–7, strict order) | full 19-service stack        |
+| **GitHub Pages**         | `pages.yml` static export                                                                                               | public, zero-backend demo    |
+| **Azure Container Apps** | `deploy-azure.yml` + ops workflows                                                                                      | live demo with real services |
+
+---
+
+## 10. The single-maintainer adaptation (what is collapsed, and why)
+
+| A 10–30 dev team has…                      | This project does instead                                                               | Why it's acceptable _for now_                                                                       |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Mandatory peer review on every PR          | **AI review** (`/review`, specialist sub-agents) + **CI gates**; maintainer self-merges | Deterministic gates catch the regressions a second human would; the AI provides a first-pass review |
+| Branch-protection blocking merge on red CI | Maintainer discipline (don't merge red)                                                 | One person, one intent; **outlook: enforce**                                                        |
+| Dedicated QA / release manager             | The pyramid + the Release workflow                                                      | Automation replaces the role, not the rigour                                                        |
+| Sprint/ceremony overhead                   | Issues + ADRs + planning index                                                          | Lightweight, async, written-down                                                                    |
+
+The point is to keep **rigour** while shedding **coordination cost**. The moment
+a second contributor joins, the Section 11 items move from "nice" to "required".
+
+---
+
+## 11. Outlook — next steps
+
+Ordered roughly by leverage. These are the gates a growing team would expect, and
+the natural maturation path for this repo:
+
+1. **Branch protection on `main`** — require the blocking CI jobs to be green and
+   the branch up to date before merge. (Highest leverage: makes the gate
+   non-bypassable, including for AI commits.)
+2. **Enforce Conventional Commits** — a `commitlint` + `commit-msg` hook so the
+   format that drives release notes can't drift.
+3. **Ship the `pre-push` test hook uniformly** — install it via the repo
+   (e.g. a `postinstall` / Husky setup) so every clone gets the fast Vitest gate,
+   not just documented behaviour.
+4. **Enforce coverage thresholds** — start with critical paths, ratchet up.
+5. **Make report-only scanners blocking** — drive the WCAG contrast ratchet
+   (Issue #25) to zero and the pentest suite to green, then drop
+   `continue-on-error`.
+6. **Automated versioning** — release-please / semantic-release for changelog +
+   semver from commit history.
+7. **Governance files** — `CONTRIBUTING.md`, `CODEOWNERS`, PR template, Issue
+   templates; **Dependabot/Renovate** for dependency PRs.
+8. **Make compliance suites blocking** once stable, and add **release provenance
+   / SLSA attestation** to releases.
+9. **Promote the compliance + Lighthouse signals into PR status** so quality is
+   visible before merge, not only after.
+
+---
+
+## 12. How to contribute
+
+### If you write code
+
+```bash
+gh issue list --repo ma3u/MinimumViableHealthDataspacev2   # pick / file an Issue
+git switch -c fix/short-slug                                # short-lived branch
+# … make the change (with or without Claude Code) …
+git commit -m "fix(scope): subject (#NN)"                  # pre-commit gate runs
+git push -u origin HEAD && gh pr create                     # CI gate runs
+# … merge once CI is green …
+```
+
+For anything architectural, **open an ADR first** (`docs/ADRs/ADR-NNN-slug.md`)
+and link it from the planning index.
+
+### If you work at the conceptual / governance / architecture layer
+
+You do **not** need to touch code to have outsized impact here — arguably the
+opposite. The highest-value contributions to an AI-assisted project are **better
+specifications**:
+
+- **File Issues** that pin down a requirement, a sequence diagram, a governance
+  rule, or a documentation gap precisely.
+- **Propose or correct ADRs** — these are exactly the durable specs the AI reads
+  every session, so a sharper ADR directly improves every future AI change.
+- **Review user-facing docs, diagrams, and journeys** and describe what's wrong
+  conceptually.
+
+That feedback becomes the **input** that makes the next AI iteration better — the
+loop is described in the companion document, [Deterministic Agentic AI
+Development with Claude Code](./AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md#8-the-human-in-the-loop-the-conceptual-review-flywheel).
+
+---
+
+## References
+
+- `CLAUDE.md` — the project's operating manual (build commands, architecture,
+  conventions, gotchas).
+- `.claude/rules/` — `code-style.md`, `testing.md`, `api-conventions.md`.
+- [ADR-008 — Testing Strategy](./ADRs/ADR-008-testing-strategy.md)
+- [ADR-026 — Token-Efficient Planning & ADR Structure](./ADRs/ADR-026-token-efficient-planning-structure.md)
+- `docs/planning-health-dataspace-v2.md` — the slim planning index.
+- Companion: [Deterministic Agentic AI Development with Claude Code](./AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)


### PR DESCRIPTION
Adds the two guideline documents requested by @medulka (Hanka) in discussion #55.

- **docs/SDLC.md** — the pragmatic, single-maintainer SDLC built on deterministic GitHub tooling: Issues + ADRs + token-efficient planning index, the local pre-commit gate, the GitHub Actions CI/CD gates (Test Suite / Protocol Compliance / Pages / Release), the four-tier testing pyramid (ADR-008), environments, the single-maintainer adaptation, and an outlook of the gates a growing team would re-introduce.
- **docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md** — how Claude Code plugs into that lifecycle: the .claude/ determinism stack, permission allow-list, slash commands, read-only specialist sub-agents, the conceptual-review flywheel, an honest strengths/risks table, and the ClaudeCodeInit bootstrap recipe.

Derived solely from the repo's actual configuration; both cross-link each other plus ADR-008 and ADR-026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)