### PR TITLE
docs(sdlc): accuracy fixes from adversarial self-review (#55)

### DIFF
--- a/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
+++ b/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
@@ -91,17 +91,25 @@ approval:
 ```jsonc
 {
   "permissions": {
+    // Abridged excerpt — the live .claude/settings.json has ~51 allow entries.
+    // A representative subset of what auto-runs:
     "allow": [
+      "Bash(git diff:*)",
+      "Bash(git status)",
       "Bash(npm test:*)",
       "Bash(npm run build:*)",
-      "Bash(git diff:*)",
-      "Bash(git status:*)",
+      "Bash(npx tsc:*)",
       "Bash(grep:*)",
       "Bash(find:*)",
-      "Bash(npx tsc:*)"
+      "Bash(docker compose ps:*)",
+      "Bash(kubectl get:*)",
+      "Bash(gh pr view:*)"
     ],
-    "deny": [],
-    "ask": []
+    "deny": [
+      "Bash(kubectl delete:*)",
+      "Bash(kubectl drain:*)",
+      "Bash(docker system prune:*)"
+    ]
   }
 }
 ```

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -138,12 +138,12 @@ The first deterministic gate runs **on your machine, before a commit is
 created** (`.git/hooks/pre-commit`, `core.hooksPath` → `.git/hooks`). It runs
 fast checks only — the heavy suite runs in CI:
 
-| Step | Tool            | What it does                                                                             |
-| ---- | --------------- | ---------------------------------------------------------------------------------------- |
-| 1    | **Prettier**    | Auto-formats staged `*.md`, `*.yaml`, `*.json`, `*.ts(x)`, `*.js(x)` and re-stages them. |
-| 2    | **ESLint**      | Lints staged TS/TSX with `--max-warnings 55` (mirrors the CI threshold).                 |
-| 3    | **tsc**         | Type-checks the UI with `tsconfig.build.json` (strict mode, excludes tests).             |
-| 4    | **Secret scan** | Blocks obvious secret patterns (`api_key`, `token`, `private_key`, …) in staged content. |
+| Step | Tool            | What it does                                                                                                    |
+| ---- | --------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1    | **Prettier**    | Auto-formats staged `*.md`, `*.yaml`, `*.json`, `*.ts(x)`, `*.js(x)` and re-stages them.                        |
+| 2    | **ESLint**      | Lints staged TS/TSX with `--max-warnings 55` — the project's ESLint warning budget (documented in `CLAUDE.md`). |
+| 3    | **tsc**         | Type-checks the UI with `tsconfig.build.json` (strict mode, excludes tests).                                    |
+| 4    | **Secret scan** | Blocks obvious secret patterns (`api_key`, `token`, `private_key`, …) in staged content.                        |
 
 Because Prettier **re-writes and re-stages** files, a commit can require a
 `git add` + retry — that is by design, not a bug.
@@ -280,7 +280,7 @@ pyramid:
 | --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------- |
 | **Unit**        | Vitest                        | pure functions, React components, API handlers mocked with `vi.mock()` — no live services, <30 s | every push (+ pre-push hook) |
 | **Integration** | Vitest + **MSW**              | API routes with mocked Neo4j responses; validates request/response shapes                        | every push                   |
-| **E2E**         | Playwright                    | full browser journeys **J001–J260** across 19 spec files                                         | `main` + dispatch            |
+| **E2E**         | Playwright                    | numbered browser journeys (`J001`+) across 35 spec files                                         | `main` + dispatch            |
 | **Compliance**  | custom (DSP TCK / DCP / EHDS) | protocol conformance                                                                             | weekly + protocol changes    |
 
 Conventions (`.claude/rules/testing.md`): unit tests in `ui/__tests__/unit/`


### PR DESCRIPTION
Follow-up to #57. An adversarial fact-check of the two guideline docs against the actual repo surfaced three inaccuracies, now corrected:

1. **CI vs pre-commit lint** — `--max-warnings 55` is enforced by the pre-commit hook (`.pre-commit-config.yaml`), not CI. CI's lint job runs plain `npm run lint` (`next lint`, no threshold). Reworded so it no longer claims CI mirrors the budget.
2. **E2E spec count** — the suite is **35** journey spec files numbered `J001`+ (verified by counting `ui/__tests__/e2e/journeys/*.spec.ts`), not the stale `J001–J260 / 19 files`.
3. **settings.json block** — was a 7-entry simplified example presented as the real config. Now labelled an **abridged excerpt** with the actual deny-list; the live file has ~51 allow entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)