### PR TITLE
docs: plain-language guides for SDLC & Agentic AI (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,22 +849,22 @@ the cost model and scheduling rationale. ADR-015 documents the single-VM fallbac
 Detailed reference documents live in the `docs/` directory. The UI documentation is also
 available online at **[ma3u.github.io/MinimumViableHealthDataspacev2/docs](https://ma3u.github.io/MinimumViableHealthDataspacev2/docs)**.
 
-| Document                                                                                | Description                                                                          |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Implementation Roadmap](docs/planning-health-dataspace-v2.md)                          | Full planning document: 12 phases, 9+ ADRs, architecture decisions.                  |
-| [Architecture Decision Records](docs/ADRs/)                                             | Standalone ADRs (001–013): data storage, testing, Azure, WCAG, security.             |
-| [Azure Deployment Guide](docs/azure-deployment-guide.md)                                | Azure Container Apps setup, endpoints, post-deploy configuration.                    |
-| [Graph Schema Reference](docs/health-dataspace-graph-schema.md)                         | Full 5-layer Neo4j schema: node labels, properties, indexes, relationships.          |
-| [E2E Test Report](docs/e2e-test-report.md)                                              | Playwright E2E results: 778 tests across 29 spec files.                              |
-| [Unit Test Coverage](docs/test-coverage-report.md)                                      | Vitest coverage: 1,490 tests, 94% statement coverage across 78 files.                |
-| [SIMPL-Open Gap Analysis](docs/simpl-ehds-gap-analysis.md)                              | Alignment assessment with EU SIMPL programme requirements.                           |
-| [Quality Gates](docs/quality-gates.md)                                                  | CI quality standards: lint, type-check, test thresholds.                             |
-| [Software Development Life Cycle (SDLC)](docs/SDLC.md)                                  | How the project plans, gates, tests, releases & deploys — with a next-steps outlook. |
-| [Agentic AI Development with Claude Code](docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md) | How AI-assisted development is kept deterministic, reviewable & safe.                |
-| [Full User Journey](docs/FULL_USER_JOURNEY.md)                                          | EHDS 8-step journey from onboarding to analytics with sequence diagram.              |
-| [OpenAPI Specs](jad/openapi/)                                                           | OpenAPI specs for all JAD services (Management, Identity, Issuer APIs).              |
-| [Bruno API Collection](bruno/MVHDv2/)                                                   | Bruno collection covering all 38 Next.js API routes with 3 environments.             |
-| [Interactive API Reference](ui/public/openapi.yaml)                                     | OpenAPI 3.1 spec rendered as Swagger UI at `/docs/developer/api`.                    |
+| Document                                                                                | Description                                                                                                                                |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Implementation Roadmap](docs/planning-health-dataspace-v2.md)                          | Full planning document: 12 phases, 9+ ADRs, architecture decisions.                                                                        |
+| [Architecture Decision Records](docs/ADRs/)                                             | Standalone ADRs (001–013): data storage, testing, Azure, WCAG, security.                                                                   |
+| [Azure Deployment Guide](docs/azure-deployment-guide.md)                                | Azure Container Apps setup, endpoints, post-deploy configuration.                                                                          |
+| [Graph Schema Reference](docs/health-dataspace-graph-schema.md)                         | Full 5-layer Neo4j schema: node labels, properties, indexes, relationships.                                                                |
+| [E2E Test Report](docs/e2e-test-report.md)                                              | Playwright E2E results: 778 tests across 29 spec files.                                                                                    |
+| [Unit Test Coverage](docs/test-coverage-report.md)                                      | Vitest coverage: 1,490 tests, 94% statement coverage across 78 files.                                                                      |
+| [SIMPL-Open Gap Analysis](docs/simpl-ehds-gap-analysis.md)                              | Alignment assessment with EU SIMPL programme requirements.                                                                                 |
+| [Quality Gates](docs/quality-gates.md)                                                  | CI quality standards: lint, type-check, test thresholds.                                                                                   |
+| [Software Development Life Cycle (SDLC)](docs/SDLC.md)                                  | How the project plans, gates, tests, releases & deploys — with a next-steps outlook. **[Plain-language version](docs/SDLC-explained.md).** |
+| [Agentic AI Development with Claude Code](docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md) | How AI-assisted development is kept deterministic, reviewable & safe. **[Plain-language version](docs/AGENTIC-AI-explained.md).**          |
+| [Full User Journey](docs/FULL_USER_JOURNEY.md)                                          | EHDS 8-step journey from onboarding to analytics with sequence diagram.                                                                    |
+| [OpenAPI Specs](jad/openapi/)                                                           | OpenAPI specs for all JAD services (Management, Identity, Issuer APIs).                                                                    |
+| [Bruno API Collection](bruno/MVHDv2/)                                                   | Bruno collection covering all 38 Next.js API routes with 3 environments.                                                                   |
+| [Interactive API Reference](ui/public/openapi.yaml)                                     | OpenAPI 3.1 spec rendered as Swagger UI at `/docs/developer/api`.                                                                          |
 
 ---
 

--- a/docs/AGENTIC-AI-explained.md
+++ b/docs/AGENTIC-AI-explained.md
@@ -1,0 +1,160 @@
+# How We Use AI to Help Build This — In Plain Language
+
+**Who this is for:** anyone wondering _"how can you trust software that an AI
+helped write?"_ — **no technical background needed.** Especially relevant if you
+work in governance, policy, ethics, clinical practice, or research.
+
+> 🤖 **Want the full technical version?** See
+> **[Deterministic Agentic AI Development with Claude Code](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)**
+> on GitHub.
+> 🔧 **Companion guide:** [How We Build This Software](./SDLC-explained.md).
+
+---
+
+## The big idea, in one sentence
+
+> An AI assistant is fast, tireless, and has "read" an enormous amount — but it
+> is also **unpredictable** and can be _confidently wrong_. So we treat it like a
+> talented new intern: give it a clear handbook, limited keys, and put its work
+> through the **same automatic checks** every human's work goes through.
+
+The AI provides _speed and breadth_. The surrounding rules and checks provide
+_trust_. Neither is enough on its own.
+
+---
+
+## Why AI needs guard-rails: the "confident intern"
+
+Picture a brilliant intern on their first week:
+
+- They've read more than anyone, and they work incredibly fast.
+- They'll happily attempt anything you ask.
+- But they don't know _your_ house rules yet, they sometimes **state wrong things
+  with great confidence**, and occasionally they invent a detail that sounds
+  plausible but isn't true. (In AI terms this is called a _hallucination_.)
+- And asked the same question twice, they might answer slightly differently each
+  time. (AI is _non-deterministic_ — there's no single fixed answer.)
+
+You wouldn't hand that intern the keys to the safe and let them publish to the
+public unsupervised. You'd give them a handbook, let them draft work, and check
+it. That is **exactly** how the AI is used here.
+
+---
+
+## The five guard-rails
+
+1. **A handbook the AI reads every time.**
+   A file called `CLAUDE.md` plus a set of rules describe this project's
+   conventions, the do's and don'ts, and the traps to avoid. The AI reads them at
+   the start of every session, so it follows house style instead of guessing.
+
+2. **Limited keys (it can look, but not unilaterally act).**
+   The AI is allowed to read files, build, and run tests freely — the harmless,
+   useful things. Anything risky (publishing, deleting, deploying) needs a
+   human's go-ahead. Like an intern with a reading-room pass but no key to the
+   archive.
+
+3. **Specialist "reviewer" personas.**
+   For tricky areas, the project can summon focused reviewers — a _security_
+   reviewer, a _compliance_ reviewer, a _testing_ reviewer. Crucially, these can
+   **only look and advise — they cannot change anything.** A wrong opinion is
+   cheap; a wrong edit is not.
+
+4. **The exact same checkpoints as a human.**
+   Whatever the AI produces must pass the identical automatic checks described in
+   the [building guide](./SDLC-explained.md) — tidiness, tests, security and
+   privacy scans, the lot. The gate doesn't care whether a human or an AI wrote
+   the change; **the checks decide what ships, not the author.**
+
+5. **A clear paper trail.**
+   Every change the AI helps with is labelled as AI-assisted in the project's
+   permanent history, so it's always clear what the machine touched — essential
+   for accountability in a health-data setting.
+
+---
+
+## The most important part: the human stays in charge
+
+Here is the idea most worth taking away — and it's where **non-technical experts
+matter most**:
+
+> An AI is only ever as good as the instructions it's given. When a domain or
+> governance expert sharpens a written rule, corrects a diagram, or describes a
+> requirement precisely, that correction becomes **permanent input the AI obeys
+> in every future session.**
+
+So "correcting the AI" is not a chore at the margins — it's the **highest-impact
+contribution** to the whole system. A clearer requirement from a policy or
+clinical expert raises the quality of _everything_ the AI produces next. The
+human expert is the steering wheel; the AI is the engine.
+
+```
+   You (expert) ─ write a clearer rule / requirement ─▶ the handbook
+        ▲                                                    │
+        │                                          the AI reads it
+        │                                                    ▼
+   review & critique ◀── the result is checked ◀── the AI proposes a change
+```
+
+This loop — expert improves the brief, AI produces better work, checks verify it,
+expert reviews — is the real method behind "using AI well."
+
+---
+
+## Honest about strengths and risks
+
+| Where the AI shines                   | Where it needs the guard-rails         | How that's handled                                       |
+| ------------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| Doing broad, repetitive work quickly  | Sounding confident while being wrong   | Automatic tests & checks catch it                        |
+| Applying the house style consistently | Drifting away from the original intent | Decision records first; small, reviewable changes        |
+| Wiring up tedious safety scaffolding  | Inventing things that aren't real      | "Base everything on what's actually here — don't invent" |
+| Never skipping a checklist step       | Doing too much / over-engineering      | A human trims the scope before it's accepted             |
+
+The pattern throughout: **the AI handles breadth; automatic checks and human
+judgement handle correctness.**
+
+---
+
+## Why this matters for health data
+
+In a regulated field like the **European Health Data Space**, you must be able to
+_trust and audit_ every change — including AI-assisted ones. The approach here
+means:
+
+- No AI change bypasses the safety and privacy checks.
+- Every AI contribution is logged and attributable.
+- A human — ideally a domain expert — remains the final decision-maker.
+
+AI is used to go _faster and broader_, never to remove the human from the loop.
+
+---
+
+## Mini-glossary (plain definitions)
+
+- **AI assistant / agent** — software that can carry out multi-step tasks on
+  instruction (here: [Claude Code](https://code.claude.com/docs/en/overview)).
+- **LLM (large language model)** — the kind of AI behind it, trained on vast text
+  to predict helpful responses.
+- **Non-deterministic** — won't always give the identical answer twice.
+- **Hallucination** — when an AI states something false but plausible-sounding.
+- **Prompt** — the instruction you give the AI.
+- **Guard-rail** — a rule or check that constrains what the AI can do.
+- **Human-in-the-loop** — keeping a person in control of key decisions.
+
+---
+
+## Further reading (external links)
+
+- [Claude Code — overview](https://code.claude.com/docs/en/overview) and
+  [on GitHub](https://github.com/anthropics/claude-code) — the AI tool used here
+- [Building Effective AI Agents](https://www.anthropic.com/research/building-effective-agents) — Anthropic (accessible, principles-first)
+- [What is a large language model?](https://en.wikipedia.org/wiki/Large_language_model) — Wikipedia
+- [AI "hallucination"](<https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence)>) — Wikipedia
+- [Human-in-the-loop](https://en.wikipedia.org/wiki/Human-in-the-loop) — Wikipedia
+- [Model Context Protocol](https://modelcontextprotocol.io/) — how AI tools connect to live data sources
+- [European Health Data Space (EHDS) Regulation](https://health.ec.europa.eu/ehealth-digital-health-and-care/european-health-data-space-regulation-ehds_en) — European Commission
+
+---
+
+- 🤖 Full technical version: **[docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)**
+- 🔧 Companion plain-language guide: **[How We Build This Software](./SDLC-explained.md)**

--- a/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
+++ b/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
@@ -1,14 +1,17 @@
 # Deterministic Agentic AI Development with Claude Code
 
-* **Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
-* **Audience:** anyone asking _"how do you actually use Agentic AI for programming
-without it going off the rails?"_
-* **Last updated:** 2026-05-31 ·
-* **Maintainer:** Matthias (`@ma3u`)
+- **Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
+- **Audience:** anyone asking _"how do you actually use Agentic AI for programming
+  without it going off the rails?"_
+- **Last updated:** 2026-05-31 ·
+- **Maintainer:** Matthias (`@ma3u`)
 
 > Companion document: **[Software Development Life Cycle
 > (SDLC)](./SDLC.md)** — the deterministic gates this AI author has to pass
 > through, same as any human contributor.
+
+> 🟢 **Not a software engineer?** Read the plain-language version first:
+> **[How We Use AI to Help Build This](./AGENTIC-AI-explained.md)**.
 
 ---
 

--- a/docs/SDLC-explained.md
+++ b/docs/SDLC-explained.md
@@ -1,0 +1,175 @@
+# How We Build This Software — In Plain Language
+
+**Who this is for:** anyone curious how this project is built and kept
+trustworthy — **no software background needed.** If you work in policy,
+governance, clinical practice, or research, this is written for you.
+
+> 🔧 **Want the full technical version?** See
+> **[Software Development Life Cycle (SDLC)](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/docs/SDLC.md)**
+> on GitHub.
+> 🤖 **Companion guide:** [How We Use AI to Help Build This](./AGENTIC-AI-explained.md).
+
+---
+
+## The big idea, in one sentence
+
+> Software changes constantly, and the people (or AI) changing it can make
+> mistakes — so every change is pushed through a series of **automatic
+> checkpoints** before it reaches the public demo, exactly the way an airport
+> screens every passenger or a pharmacy double-checks every prescription.
+
+The goal is **trust**: you should be able to see _what_ changed, _when_, _why_,
+and _that it was checked_ — which matters enormously for anything touching health
+data.
+
+---
+
+## A quick analogy: the professional kitchen
+
+Imagine a restaurant kitchen that has to be spotless every single service:
+
+| In a kitchen…                                              | In this project…                                    |
+| ---------------------------------------------------------- | --------------------------------------------------- |
+| Every dish follows a written recipe                        | Written rules and conventions everyone follows      |
+| A new dish is trialled on the side before it hits the menu | Changes are drafted on a **copy**, not the live app |
+| The head chef tastes it before it goes out                 | A **review** happens before anything is published   |
+| Health inspectors check hygiene, every time, the same way  | **Automatic checks** run on every change            |
+| The menu has dated editions                                | Each public version gets a **version number**       |
+| There's a logbook of why recipes changed                   | **Decision records** explain the _why_              |
+
+Nobody relies on "I'm sure it's fine." The _process_ guarantees quality, not any
+one person's memory or mood.
+
+---
+
+## How a change actually happens (step by step)
+
+1. **An idea or problem is written down.** Usually as a GitHub _Issue_ — a public
+   to-do card describing what needs fixing or building.
+2. **If it's a big decision, the reasoning is recorded first.** This is an
+   _Architecture Decision Record_ (ADR) — a short "here's what we decided and
+   why" note, kept forever. Like the minutes of a meeting that future people (and
+   the AI) can always read back.
+3. **The change is drafted on a side copy** (a "branch") — never directly on the
+   live version. Think _suggesting mode_ in a shared document: you propose edits
+   without touching the original.
+4. **Automatic checkpoints run on your own computer** the moment the change is
+   saved — a quick spell-check, tidy-up, and safety scan (see _The checkpoints_
+   below).
+5. **The change is proposed for review** as a _Pull Request_ — a side-by-side
+   "before and after" anyone can inspect and comment on.
+6. **A bigger battery of automatic checks runs in the cloud** — the same way for
+   everyone, on neutral machines, so nobody's laptop quirks matter.
+7. **Only if everything passes (green)** does the change get merged into the
+   official version.
+8. **The public demo and the live system rebuild themselves automatically** from
+   that official version. No manual "uploading to the server" by hand.
+
+The human judgement lives at the top (steps 1–3: _what_ and _why_). Everything
+below is automated and repeatable — it runs the same way at 3pm on a Tuesday as
+at midnight on a Sunday.
+
+---
+
+## The checkpoints (what the "automatic checks" actually check)
+
+Think of these as inspectors who never get tired and never skip a step:
+
+- **Tidiness.** Formatting is auto-corrected so everything looks consistent —
+  like a copy-editor standardising a document's layout.
+- **Obvious-mistake detector.** Flags common coding slip-ups before they spread.
+- **Consistency / type checks.** Confirms the pieces still fit together.
+- **Tests.** A robot re-runs the app and clicks through it to confirm nothing
+  broke — like a car going through a full inspection before it's sold.
+- **Security & privacy scans.** Look for accidentally-leaked passwords, known
+  weaknesses, and risky dependencies — and produce a _Software Bill of
+  Materials_ (an ingredients list of every third-party component, much like a
+  food label).
+- **Accessibility checks.** Confirm the interface is usable by people with
+  disabilities.
+
+If any inspector raises a red flag, the change simply cannot go live until it's
+fixed. There's no "just this once."
+
+---
+
+## Decision records: the project's long-term memory
+
+Every significant choice ("why two databases?", "how do we test?", "how do we
+keep cloud costs down?") is written up as a numbered **ADR**. There are 27 of
+them so far. They're short, plain, and dated, and they answer the question every
+newcomer eventually asks: _"why was it done this way?"_ — without anyone having
+to remember.
+
+This is one of the most useful things a non-technical contributor can engage
+with: **you don't need to read code to read or question a decision record.**
+
+---
+
+## Why this matters for health data
+
+This project is a reference implementation for the **European Health Data Space
+(EHDS)** — the EU's framework for safely using and sharing health data. In that
+world, _how_ you build is part of _whether you can be trusted_:
+
+- **Auditability.** Every change is permanently logged with its author, time, and
+  reason. You can prove what happened.
+- **Repeatability.** The same checks run every time, so quality doesn't depend on
+  who was on shift.
+- **Safety nets.** Privacy and security scans run automatically, not just when
+  someone remembers.
+- **Transparency.** Decisions are written down in plain language, not locked in
+  one person's head.
+
+These are exactly the properties regulators, hospitals, and patients expect.
+
+---
+
+## "But it's a one-person project?"
+
+Yes — today it's one maintainer plus an AI assistant. The trick is that the
+**automatic checkpoints replace what a large team's reviewers would do.** A team
+of 10–30 would add mandatory human peer-review and a few more guard-rails; the
+[technical guide](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/docs/SDLC.md)
+lists exactly which ones would be re-introduced as the project grows. The
+_rigour_ is kept; only the _people-coordination overhead_ is trimmed.
+
+---
+
+## Mini-glossary (plain definitions)
+
+- **Repository ("repo")** — the project's folder of files, with full history.
+- **Git / version control** — a system that remembers every change ever made and
+  lets you rewind, like an infinite "track changes."
+- **Branch** — a side copy where a change is drafted safely.
+- **Pull Request (PR)** — a proposed change, shown as before/after, open for
+  review before it's accepted.
+- **Merge** — accepting a proposed change into the official version.
+- **CI/CD (the cloud checkpoints)** — "Continuous Integration / Continuous
+  Delivery": the automated build-test-publish pipeline.
+- **Test** — an automatic check that the software still behaves correctly.
+- **ADR (Architecture Decision Record)** — a short written note recording a
+  decision and the reasoning behind it.
+- **Release / version number** — a labelled, published edition of the software.
+- **Deploy** — making a version live for people to use.
+
+---
+
+## Further reading (external links)
+
+Friendly, non-vendor explanations if you'd like to go a little deeper:
+
+- [What is version control?](https://www.atlassian.com/git/tutorials/what-is-version-control) — Atlassian
+- [What is Continuous Integration / CI/CD?](https://www.atlassian.com/continuous-delivery/continuous-integration) — Atlassian
+- [Software (systems) development life cycle](https://en.wikipedia.org/wiki/Systems_development_life_cycle) — Wikipedia
+- [Code review](https://en.wikipedia.org/wiki/Code_review) — Wikipedia
+- [Architecture Decision Records](https://adr.github.io/) — overview, and the original
+  [Nygård template](https://github.com/joelparkerhenderson/architecture-decision-record)
+- [Conventional Commits](https://www.conventionalcommits.org/) — the standard way changes are labelled
+- [Trunk-based development](https://trunkbaseddevelopment.com/) — the branching style used here
+- [European Health Data Space (EHDS) Regulation](https://health.ec.europa.eu/ehealth-digital-health-and-care/european-health-data-space-regulation-ehds_en) — European Commission · [legal text (EU) 2025/327](https://eur-lex.europa.eu/eli/reg/2025/327/oj/eng)
+
+---
+
+- 🔧 Full technical version: **[docs/SDLC.md](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/docs/SDLC.md)**
+- 🤖 Companion plain-language guide: **[How We Use AI to Help Build This](./AGENTIC-AI-explained.md)**

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -1,14 +1,17 @@
 # Software Development Life Cycle (SDLC)
 
-* **Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
-* **Audience:** contributors, reviewers, and anyone curious how a one-person,
-AI-assisted project keeps a regulated-domain codebase shippable.
-* **Last updated:** 2026-05-31
-* **Maintainer:** Matthias (`@ma3u`)
+- **Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
+- **Audience:** contributors, reviewers, and anyone curious how a one-person,
+  AI-assisted project keeps a regulated-domain codebase shippable.
+- **Last updated:** 2026-05-31
+- **Maintainer:** Matthias (`@ma3u`)
 
 > Companion document: **[Deterministic Agentic AI Development with Claude
 > Code](./AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md)** — how the AI author plugs
 > into the lifecycle described here.
+
+> 🟢 **Not a software engineer?** Read the plain-language version first:
+> **[How We Build This Software](./SDLC-explained.md)**.
 
 ---
 


### PR DESCRIPTION
Adds two non-technical companion guides aimed at non-software-engineers (e.g. governance, policy, clinical, research readers such as @medulka):

- [docs/SDLC-explained.md](docs/SDLC-explained.md) — *How We Build This Software, In Plain Language*
- [docs/AGENTIC-AI-explained.md](docs/AGENTIC-AI-explained.md) — *How We Use AI to Help Build This, In Plain Language*

Each explains the topic with everyday analogies, links to the full **technical** file on GitHub, and ends with a curated **Further reading** list of external links. Also adds a plain-language banner atop each technical doc and 'Plain-language version' links in the README Documentation table.

Follow-up to #57–#60.