### PR TITLE
docs(agentic): clarity pass to match SDLC (#55)

### DIFF
--- a/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
+++ b/docs/AGENTIC-DEVELOPMENT-WITH-CLAUDE-CODE.md
@@ -3,7 +3,7 @@
 - **Project:** Minimum Viable Health Dataspace v2 (EHDS reference implementation)
 - **Audience:** anyone asking _"how do you actually use Agentic AI for programming
   without it going off the rails?"_
-- **Last updated:** 2026-05-31 ·
+- **Last updated:** 2026-06-01
 - **Maintainer:** Matthias (`@ma3u`)
 
 > Companion document: **[Software Development Life Cycle
@@ -31,8 +31,8 @@
 
 ## 1. The thesis: wrap a non-deterministic author in a deterministic harness
 
-Large Language Models are **non-deterministic**. Ask the same question twice and
-you may get two different answers. Software, by contrast, demands
+Large Language Models (LLMs) are **non-deterministic**. Ask the same question
+twice and you may get two different answers. Software, by contrast, demands
 **determinism** — the build is reproducible, the tests are reproducible, the
 deployment is reproducible.
 
@@ -44,13 +44,24 @@ The whole craft of "agentic AI for programming" is bridging that gap:
 
 The agent supplies _breadth and speed_. The harness supplies _determinism and
 trust_. Neither is sufficient alone. This document describes the harness I use
-with [Claude Code](https://claude.com/claude-code) on this project, and the rules
-of engagement that keep AI-generated code reviewable and safe in a
-regulated-health-data domain.
+with [Claude Code](https://code.claude.com/docs/en/overview) on this project, and
+the rules of engagement that keep AI-generated code reviewable and safe in a
+regulated-health-data domain. The general principles behind this approach are
+laid out well in Anthropic's
+[Building Effective Agents](https://www.anthropic.com/research/building-effective-agents).
 
 The guiding principle, borrowed from how I run human teams:
 **Evidence > assumptions · Code > documentation · The gate, not the author,
 decides what ships.**
+
+### Why this matters
+
+This is a reference implementation for the **European Health Data Space (EHDS)**,
+a regulated domain. Using AI there is only acceptable if you can still _trust and
+audit_ every change. The layered harness below is what makes that true: the AI
+goes _faster and broader_, but it can never quietly ship something that bypasses
+the project's safety, privacy, and review checks. A human — ideally a domain
+expert — stays the final decision-maker (§8).
 
 ---
 
@@ -58,19 +69,31 @@ decides what ships.**
 
 Determinism is layered. Each layer narrows what the agent _can_ do and sharpens
 what it _should_ do, so that by the time code reaches the deterministic gates it
-is already shaped by the project's rules.
+is already shaped by the project's rules. Read the diagram top-to-bottom: each
+layer adds a constraint, and the bottom layer (L6) is the same gate a human
+passes.
 
 ```mermaid
 flowchart TD
-    L0["L0 · Spec — CLAUDE.md + .claude/rules/*\n(single source of truth, read every session)"]
-    L1["L1 · Constrained tools — settings.json allow-list\n(safe ops auto-run, the rest needs approval)"]
-    L2["L2 · Durable memory — ADRs + planning index\n(why decisions were made)"]
-    L3["L3 · Repeatable prompts — slash commands\n(/review, /fix-issue, /deploy-check)"]
-    L4["L4 · Specialist sub-agents — architect, compliance,\ntester, security (read-only, scoped)"]
-    L5["L5 · Skills — domain packs (health-dataspace)"]
-    L6["L6 · Deterministic gates — pre-commit + CI/CD\n(the SAME gates a human passes)"]
+    L0["🧭 L0 · Spec<br/>CLAUDE.md + .claude/rules/*<br/>(read every session)"]
+    L1["🔑 L1 · Constrained tools<br/>settings.json allow-list<br/>(safe ops auto-run; rest needs approval)"]
+    L2["📚 L2 · Durable memory<br/>ADRs + planning index<br/>(why decisions were made)"]
+    L3["⚙️ L3 · Repeatable prompts<br/>slash commands"]
+    L4["👥 L4 · Specialist sub-agents<br/>architect · compliance · tester · security<br/>(read-only, scoped)"]
+    L5["🧩 L5 · Skills<br/>domain packs (health-dataspace)"]
+    L6["✅ L6 · Deterministic gates<br/>pre-commit + CI/CD<br/>(the SAME gates a human passes)"]
     L0 --> L1 --> L2 --> L3 --> L4 --> L5 --> L6
 ```
+
+| Layer  | What it is                                     | Why it matters                                                                  |
+| ------ | ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| **L0** | The written spec the agent reads every session | Without it the agent guesses your conventions; with it, it follows house style. |
+| **L1** | An allow-list of tool calls (§4)               | Limits the _blast radius_ — the AI can't push, delete, or deploy on its own.    |
+| **L2** | ADRs + planning index (§3)                     | Gives the agent the _why_, so it stays consistent with past decisions.          |
+| **L3** | Slash commands (§5)                            | Turns ad-hoc prompts into repeatable, reviewed workflows.                       |
+| **L4** | Read-only specialist reviewers (§6)            | Expert second opinions that can advise but never silently edit.                 |
+| **L5** | Skills — task-triggered domain playbooks       | Encodes "the way we do X here" for recurring task types.                        |
+| **L6** | The deterministic gates (pre-commit + CI/CD)   | The final arbiter — AI output ships only if it passes, exactly like a human's.  |
 
 The bottom layer (L6) is shared with humans and is documented in the
 [SDLC](./SDLC.md). The layers above it are the _agentic_ scaffolding and are the
@@ -91,20 +114,22 @@ contributor.
 | [`.claude/rules/code-style.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/code-style.md)           | TypeScript/Next.js + Cypher + Bash + Prettier conventions, scoped to source paths.                                                                                                                                                           |
 | [`.claude/rules/testing.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/testing.md)                 | Test frameworks, locations, commands, what _not_ to mock.                                                                                                                                                                                    |
 | [`.claude/rules/api-conventions.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/api-conventions.md) | Protocols (DSP/DCP/FHIR/OMOP/EHDS/GDPR), data models, route patterns, role/access matrix, mock-fixture mapping.                                                                                                                              |
-| `.claude/commands/*.md`                                                                                                                 | **Slash commands** — repeatable, parameterised prompts (§5).                                                                                                                                                                                 |
-| `.claude/agents/*.md`                                                                                                                   | **Specialist sub-agents** — scoped, read-only experts (§6).                                                                                                                                                                                  |
+| [`.claude/commands/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/commands)                                | **Slash commands** — repeatable, parameterised prompts (§5).                                                                                                                                                                                 |
+| [`.claude/agents/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/agents)                                    | **Specialist sub-agents** — scoped, read-only experts (§6).                                                                                                                                                                                  |
 | [`.claude/skills/SKILL.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/skills/SKILL.md)                   | A domain **skill** pack auto-triggered by task type.                                                                                                                                                                                         |
 
-Because this lives in git, improving the agent is a normal PR: change a rule,
-review the diff, merge. The agent's behaviour is **configuration, not folklore**.
+**Why it matters:** because this lives in git, improving the agent is a normal
+PR — change a rule, review the diff, merge. The agent's behaviour is
+**configuration, not folklore**: anyone can see exactly what governs it, and
+changes are themselves reviewed.
 
 ---
 
 ## 4. Constrained tools & permissions (blast-radius control)
 
-`.claude/settings.json` is an **allow-list**. Read-only and obviously-safe
-operations run without interrupting the flow; everything else requires explicit
-approval:
+[`.claude/settings.json`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/settings.json)
+is an **allow-list**. Read-only and obviously-safe operations run without
+interrupting the flow; everything else requires explicit human approval:
 
 ```jsonc
 {
@@ -134,8 +159,13 @@ approval:
 
 The agent can freely **inspect, build, type-check, and test** — the actions you
 _want_ it doing constantly. Anything that mutates outside the working tree
-(pushing, deleting, deploying, installing) surfaces for a human decision. This is
-the "least privilege" principle applied to an AI author.
+(pushing, deleting, deploying, installing) surfaces for a human decision.
+
+**Why it matters:** this is the
+[principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)
+applied to an AI author — give it exactly the access it needs to be useful, and
+no more, so a mistaken or misunderstood instruction can't cause irreversible
+damage.
 
 ---
 
@@ -145,14 +175,16 @@ A free-form prompt is non-deterministic by nature. A **slash command** is a
 checked-in, version-controlled prompt that produces a _consistent workflow_ every
 time it's invoked — the determinism trick applied to the instruction itself.
 
-| Command          | What it does                                                                                                                                                                                                                                   |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/review`        | Reviews the working `git diff` against this project's conventions: TS strict mode + `@/*` imports, Cypher `MERGE`-only + PascalCase labels, **fictional org names only**, mock fixtures kept in sync with API routes, tests for new behaviour. |
-| `/fix-issue <N>` | Investigates a GitHub Issue end-to-end: `gh issue view N` → locate relevant files → implement → verify.                                                                                                                                        |
-| `/deploy-check`  | Pre-deployment validation using the project's real build/test commands.                                                                                                                                                                        |
+| Command                                                                                                              | What it does                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/review`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/review.md)             | Reviews the working `git diff` against this project's conventions: TS strict mode + `@/*` imports, Cypher `MERGE`-only + PascalCase labels, **fictional org names only**, mock fixtures kept in sync with API routes, tests for new behaviour. |
+| [`/fix-issue <N>`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/fix-issue.md)   | Investigates a GitHub Issue end-to-end: `gh issue view N` → locate relevant files → implement → verify.                                                                                                                                        |
+| [`/deploy-check`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/deploy-check.md) | Pre-deployment validation using the project's real build/test commands.                                                                                                                                                                        |
 
-These encode "the way we do X here" once, so the _quality of the prompt_ no
-longer depends on how I phrased it that day.
+**Why it matters:** these encode "the way we do X here" once, so the _quality of
+the review or workflow_ no longer depends on how well I happened to phrase the
+prompt that day. A command is a prompt you can review, version, and improve like
+any other code.
 
 ---
 
@@ -161,12 +193,12 @@ longer depends on how I phrased it that day.
 For deep reasoning in one domain, the project ships **specialist sub-agents**
 under [`.claude/agents/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/agents). Each is deliberately constrained:
 
-| Agent                   | When to use it                                                                                                        | Model  | Tools                                |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------ |
-| **architect**           | Reason about the 5-layer Neo4j graph, DSP/FHIR/OMOP/DCAT-AP interactions, service topology, cross-cutting trade-offs. | Sonnet | `Read, Grep, Glob, Bash` (read-only) |
-| **compliance-reviewer** | Verify EHDS conformance, DSP/DCP protocol correctness, GDPR patient-rights, audit-trail integrity.                    | Sonnet | read-only                            |
-| **tester**              | Audit coverage, triage test failures, plan new Playwright journeys, assess Vitest health.                             | Sonnet | read-only                            |
-| **security**            | Review auth flows, RBAC, Keycloak config, credential/secret handling, vulnerabilities.                                | Sonnet | read-only                            |
+| Agent                   | When to use it                                                                                                                              | Model  | Tools                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------ |
+| **architect**           | Reason about the 5-layer Neo4j graph, DSP/FHIR/OMOP/DCAT-AP interactions, service topology, cross-cutting trade-offs.                       | Sonnet | `Read, Grep, Glob, Bash` (read-only) |
+| **compliance-reviewer** | Verify EHDS conformance, DSP/DCP protocol correctness, GDPR patient-rights, audit-trail integrity.                                          | Sonnet | read-only                            |
+| **tester**              | Audit coverage, triage test failures, plan new [Playwright](https://playwright.dev/) journeys, assess [Vitest](https://vitest.dev/) health. | Sonnet | read-only                            |
+| **security**            | Review auth flows, RBAC, [Keycloak](https://www.keycloak.org/) config, credential/secret handling, vulnerabilities.                         | Sonnet | read-only                            |
 
 Two deliberate constraints make these safe:
 
@@ -178,37 +210,45 @@ Two deliberate constraints make these safe:
    and economical, with the orchestrating session retaining the harder
    reasoning.
 
-This mirrors a real team: you bring in a security or compliance reviewer to _look
-and advise_, not to silently rewrite your branch.
+**Why it matters:** this mirrors a real team. You bring in a security or
+compliance reviewer to _look and advise_, not to silently rewrite your branch —
+and in a health-data project, an independent compliance/security read is exactly
+the kind of second opinion you want before merge.
 
 ---
 
 ## 7. Rules of engagement (the determinism techniques)
 
-These are the habits — encoded in `CLAUDE.md` and the rules files — that keep
-agent output predictable and trustworthy:
+These are the habits — encoded in [`CLAUDE.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/CLAUDE.md) and the
+[rules files](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/rules) — that keep agent
+output predictable and trustworthy. Each one closes a specific failure mode of
+AI-assisted coding:
 
-- **Read before write.** Always inspect a file before editing it. No blind edits.
+- **Read before write.** Always inspect a file before editing it. _Why:_ blind
+  edits are how an AI corrupts code it didn't fully understand.
 - **Idempotent by default.** Cypher uses `MERGE`, never bare `CREATE`; schema
-  constraints use `IF NOT EXISTS`. Re-running a change is a no-op, not a
-  duplication — so a retried or repeated agent action is safe.
+  constraints use `IF NOT EXISTS`. _Why:_ re-running a change is then a no-op, so a
+  retried or repeated agent action is safe rather than duplicating data.
 - **Plan / ADR first for big changes.** Architectural work starts with an ADR
-  (see [SDLC §3](./SDLC.md#3-plan-before-you-build-issues-adrs-and-a-token-efficient-plan)),
-  so the _decision_ is reviewed before a single line is written.
+  (see [SDLC §3](./SDLC.md#3-plan-before-you-build-issues-adrs-and-a-token-efficient-plan)).
+  _Why:_ the _decision_ is reviewed before a single line is written, so the agent
+  can't quietly take the project in the wrong direction.
 - **Token-efficient context** ([ADR-026](./ADRs/ADR-026-token-efficient-planning-structure.md)).
-  Routinely-loaded docs are kept under **~15K tokens**. A sharp, relevant context
-  produces sharper reasoning — load the ADR _index_ then the one relevant ADR,
-  not the whole corpus.
+  Routinely-loaded docs are kept under **~15K tokens**. _Why:_ a sharp, relevant
+  context produces sharper reasoning — load the ADR _index_ then the one relevant
+  ADR, not the whole corpus.
 - **Evidence over assertion.** A change isn't "done" because the agent says so —
-  it's done when the **gates are green** (lint, type-check, tests, scans). The
-  [SDLC](./SDLC.md) gates apply to AI commits identically to human commits.
-- **Traceable provenance.** AI-assisted commits carry a `Co-Authored-By: Claude`
-  trailer, so `git log` always shows what the agent touched — essential for audit
-  in a health-data context.
+  it's done when the **gates are green** (lint, type-check, tests, scans). _Why:_
+  the [SDLC](./SDLC.md) gates apply to AI commits identically to human commits.
+- **Traceable provenance.** AI-assisted commits carry a
+  [`Co-Authored-By: Claude`](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)
+  trailer. _Why:_ `git log` always shows what the agent touched — essential for
+  audit in a health-data context.
 - **Domain guardrails.** Hard rules the agent must never break — e.g. **only
   fictional organisation names** in demo data and docs (AlphaKlinik Berlin,
-  PharmaCo Research AG, …; never real entities). These live in the rules files
-  and are checked by `/review`.
+  PharmaCo Research AG, …; never real entities). _Why:_ these protect against
+  reputational and privacy harms; they live in the rules files and are checked by
+  [`/review`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/review.md).
 
 ---
 
@@ -218,12 +258,17 @@ The most important part of agentic development is **not** the AI — it's the
 **feedback loop** that turns human expertise into better specifications.
 
 ```mermaid
-flowchart LR
-    H["Human expert\n(architecture · governance · domain)"] -->|"sharper spec:\nIssue / ADR / corrected doc"| S["Spec\nCLAUDE.md · ADRs · rules"]
-    S -->|"read every session"| A["Claude Code\nproposes change"]
-    A -->|"PR"| G["Deterministic gates\n(SDLC)"]
-    G -->|"merged result"| R["Running system + docs"]
-    R -->|"review & critique"| H
+flowchart TD
+    H["🧑‍⚖️ Human expert<br/>(architecture · governance · domain)"]
+    S["📋 Spec<br/>CLAUDE.md · ADRs · rules"]
+    A["🤖 Claude Code<br/>proposes a change"]
+    G["✅ Deterministic gates<br/>(SDLC)"]
+    R["🚀 Running system + docs"]
+    H -->|"sharper spec: Issue / ADR / corrected doc"| S
+    S -->|"read every session"| A
+    A -->|"Pull Request"| G
+    G -->|"merged result"| R
+    R -->|"review &amp; critique"| H
 ```
 
 An AI agent is only as good as the spec it reads. When a human corrects a
@@ -233,22 +278,23 @@ highest-leverage contribution to this project is often **conceptual, not
 code**: better requirements, clearer governance rules, corrected architecture
 descriptions. Each one raises the floor of everything the AI produces next.
 
-This is the answer to _"how to best use Agentic AI for programming"_: don't aim
-for a hands-off autopilot. Aim for a **tight loop** where human judgement
-continuously sharpens the spec, and deterministic tooling continuously verifies
-the output.
+**Why it matters:** this is the answer to _"how to best use Agentic AI for
+programming."_ Don't aim for a hands-off autopilot — aim for a **tight loop**
+where human judgement continuously sharpens the spec, and deterministic tooling
+continuously verifies the output. The domain expert is the steering wheel; the AI
+is the engine.
 
 ---
 
 ## 9. Strengths, risks, and mitigations (an honest assessment)
 
-| Where agentic AI excels here                                              | Where it needs the harness                             | Mitigation in this project                                                                                 |
-| ------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| Breadth — wiring CI, security scanners, SBOM, multi-layer schemas quickly | **Confidently wrong** output (plausible but incorrect) | Deterministic gates (tests, type-check, scans); `/review`; read-only specialist sub-agents                 |
-| Consistency — applies project conventions uniformly                       | **Drift from intent** over a long task                 | ADR-first for big changes; small PRs; human review of the diff                                             |
-| Speed — repetitive refactors, fixtures, boilerplate                       | **Hallucinated APIs / fabricated facts**               | "Base everything strictly on the repo, don't invent" (the init recipe, §10); CI catches non-existent calls |
-| Tireless — never skips a checklist step                                   | **Over-engineering / scope creep**                     | KISS/YAGNI in the rules; maintainer trims scope at PR                                                      |
-| Great at scaffolding tedious safety work                                  | **Blast radius** if given broad tools                  | Permission allow-list; least-privilege tools (§4)                                                          |
+| Where agentic AI excels here                                              | Where it needs the harness                                                                                          | Mitigation in this project                                                                                                                                                                |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Breadth — wiring CI, security scanners, SBOM, multi-layer schemas quickly | **Confidently wrong** output (plausible but incorrect)                                                              | Deterministic gates (tests, type-check, scans); [`/review`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/review.md); read-only specialist sub-agents |
+| Consistency — applies project conventions uniformly                       | **Drift from intent** over a long task                                                                              | ADR-first for big changes; small PRs; human review of the diff                                                                                                                            |
+| Speed — repetitive refactors, fixtures, boilerplate                       | **[Hallucinated](<https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence)>) APIs / fabricated facts** | "Base everything strictly on the repo, don't invent" (the init recipe, §10); CI catches non-existent calls                                                                                |
+| Tireless — never skips a checklist step                                   | **Over-engineering / scope creep**                                                                                  | [KISS](https://en.wikipedia.org/wiki/KISS_principle) / [YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it) in the rules; maintainer trims scope at PR                       |
+| Great at scaffolding tedious safety work                                  | **Blast radius** if given broad tools                                                                               | Permission allow-list; least-privilege tools (§4)                                                                                                                                         |
 
 The pattern: **AI handles the breadth; deterministic tooling and human judgement
 handle the correctness.**
@@ -258,19 +304,17 @@ handle the correctness.**
 ## 10. The init recipe — bootstrapping Claude Code on any repo
 
 The `.claude/` setup above wasn't hand-written from scratch — it was generated by
-pointing Claude Code at the existing repo with a single, carefully-bounded
-instruction, then reviewed like any other change. The reusable recipe is
-published as a gist:
+pointing [Claude Code](https://code.claude.com/docs/en/overview) at the existing
+repo with a single, carefully-bounded instruction, then reviewed like any other
+change. The reusable recipe is published as a gist:
 
 **→ [ClaudeCodeInit — the bootstrap prompt](https://gist.github.com/ma3u/09e76d3b604d132673bc4a59b092709a)**
 
 In summary, it asks the agent to _read all planning and architecture docs in the
 repo_ and generate a complete `.claude/` folder:
 
-1. **`CLAUDE.md`** — concise: build commands, architecture, key dirs,
-   conventions, top project-specific gotchas.
-2. **[`settings.json`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/settings.json)** — allow safe ops (build/test/git-read/grep/find), require
-   approval for destructive actions.
+1. **[`CLAUDE.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/CLAUDE.md)** — concise: build commands, architecture, key dirs, conventions, top project-specific gotchas.
+2. **[`settings.json`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/settings.json)** — allow safe ops (build/test/git-read/grep/find), require approval for destructive actions.
 3. **[`code-style.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/code-style.md)** — conventions extracted from the _actual_ codebase.
 4. **[`testing.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/testing.md)** — real test frameworks, commands, standards.
 5. **[`api-conventions.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/rules/api-conventions.md)** — protocols, data models, API patterns.
@@ -278,42 +322,42 @@ repo_ and generate a complete `.claude/` folder:
 7. **[`fix-issue.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/fix-issue.md)** — an Issue-investigation workflow with `gh` CLI.
 8. **[`deploy-check.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/commands/deploy-check.md)** — pre-deploy validation using the real build command.
 9. **[`SKILL.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/skills/SKILL.md)** — domain skill packs, auto-triggered by task type.
-10. **`agents/`** — specialist read-only agents (architect, compliance, tester,
-    security) on Sonnet.
+10. **[`agents/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/agents)** — specialist read-only agents (architect, compliance, tester, security) on Sonnet.
 
 The one constraint that makes it trustworthy:
 
 > **"Base all content strictly on what you find in this repository. Do not invent
 > architecture or conventions not present in the code or docs."**
 
-That single rule is what turns a generic AI into a _project-specific_ one — and
-it's the same anti-hallucination discipline that runs through everything above.
+**Why it matters:** that single rule is what turns a generic AI into a
+_project-specific_ one — and it's the same anti-hallucination discipline that runs
+through everything above.
 
 ---
 
 ## 11. Outlook — maturing the agentic setup
 
-1. **Claude in CI** — automated PR review via the Claude GitHub app/Action, so
-   every PR gets an AI first-pass review on the server, not just locally.
-2. **Branch protection** (see [SDLC §11](./SDLC.md#11-outlook--next-steps)) so
-   even AI commits cannot bypass green CI.
+1. **Claude in CI** (Continuous Integration) — automated PR review via the Claude
+   GitHub app/Action, so every PR gets an AI first-pass review on the server, not
+   just locally.
+2. **Branch protection** (see [SDLC §11](./SDLC.md#11-outlook--next-steps)) so even
+   AI commits cannot bypass green CI.
 3. **Commit-message enforcement** (`commitlint`) so AI-authored commits keep the
-   Conventional-Commit shape that drives release notes.
-4. **Live context via MCP** — Model Context Protocol servers exposing Neo4j /
-   FHIR so the agent can reason against _current_ data, not just the schema.
+   [Conventional Commits](https://www.conventionalcommits.org/) shape that drives
+   release notes.
+4. **Live context via [MCP](https://modelcontextprotocol.io/)** — Model Context
+   Protocol servers exposing Neo4j / FHIR so the agent can reason against
+   _current_ data, not just the schema.
 5. **An eval / regression harness for agent output** — golden tasks the setup is
-   re-run against when `CLAUDE.md` or the rules change, so configuration changes
-   are themselves tested.
+   re-run against when [`CLAUDE.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/CLAUDE.md) or the rules
+   change, so configuration changes are themselves tested.
 
 ---
 
 ## References
 
-- `CLAUDE.md`, `.claude/settings.json`, `.claude/rules/*`, `.claude/commands/*`,
-  `.claude/agents/*`, `.claude/skills/SKILL.md` — the live configuration.
-- [ClaudeCodeInit gist](https://gist.github.com/ma3u/09e76d3b604d132673bc4a59b092709a)
-  — the bootstrap recipe.
-- [ADR-026 — Token-Efficient Planning & ADR Structure](./ADRs/ADR-026-token-efficient-planning-structure.md)
-- [ADR-008 — Testing Strategy](./ADRs/ADR-008-testing-strategy.md)
-- Companion: [Software Development Life Cycle (SDLC)](./SDLC.md)
-- [Claude Code](https://claude.com/claude-code)
+- [`CLAUDE.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/CLAUDE.md), [`.claude/settings.json`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/settings.json), [`.claude/rules/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/rules), [`.claude/commands/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/commands), [`.claude/agents/`](https://github.com/ma3u/MinimumViableHealthDataspacev2/tree/main/.claude/agents), [`.claude/skills/SKILL.md`](https://github.com/ma3u/MinimumViableHealthDataspacev2/blob/main/.claude/skills/SKILL.md) — the live configuration.
+- [ClaudeCodeInit gist](https://gist.github.com/ma3u/09e76d3b604d132673bc4a59b092709a) — the bootstrap recipe.
+- [Claude Code documentation](https://code.claude.com/docs/en/overview) · [Claude Code on GitHub](https://github.com/anthropics/claude-code) · [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) (Anthropic).
+- [ADR-026 — Token-Efficient Planning & ADR Structure](./ADRs/ADR-026-token-efficient-planning-structure.md) · [ADR-008 — Testing Strategy](./ADRs/ADR-008-testing-strategy.md)
+- Companion: [Software Development Life Cycle (SDLC)](./SDLC.md) · plain-language: [How We Use AI to Help Build This](./AGENTIC-AI-explained.md)


### PR DESCRIPTION
Mirrors the SDLC clarity pass (#63) onto the Agentic-AI technical doc:

- **Per-section 'why it matters'** explanations, plus a per-layer table for the determinism stack.
- **Both mermaid diagrams** redrawn **top-down** with `<br/>` line breaks (the determinism stack and the human-in-the-loop flywheel — the flywheel was previously a cramped left-to-right diagram).
- **More links** — fixed the Claude Code URL (`code.claude.com/docs`) and added: Building Effective Agents, MCP, Conventional Commits, Keycloak, principle of least privilege, KISS/YAGNI, AI hallucination, Vitest/Playwright, and GitHub multi-author commits; linked the `.claude/commands` and `.claude/agents` directories and the slash-command files.
- Acronym glossary (added in #63) retained.

Follow-up to #63.