### PR TITLE
fix(eudi): use verifier-backend.eudiw.dev API host (live 502 fix)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -69,7 +69,7 @@ jobs:
             --image ${{ env.ACR_LOGIN_SERVER }}/mvhd-ui:${{ github.sha }} \
             --set-env-vars \
               "DEPLOYMENT_TARGET=azure" \
-              "EUDI_VERIFIER_BASE_URL=https://verifier.eudiw.dev" \
+              "EUDI_VERIFIER_BASE_URL=https://verifier-backend.eudiw.dev" \
               "EUDI_VERIFIER_SCHEME=openid4vp://" \
               "EUDI_VERIFIER_PROFILE=openid4vp" \
               "EUDI_PID_DOCTYPE=eu.europa.ec.eudi.pid.1" \

--- a/scripts/azure/05-cfm-ui.sh
+++ b/scripts/azure/05-cfm-ui.sh
@@ -94,7 +94,7 @@ az containerapp create \
     "EDC_PROVISION_URL=${EDC_PROVISION_URL}" \
     "EDC_SERVICE_CLIENT_ID=admin" \
     "EDC_SERVICE_CLIENT_SECRET=edc-v-admin-secret" \
-    "EUDI_VERIFIER_BASE_URL=${EUDI_VERIFIER_BASE_URL:-https://verifier.eudiw.dev}" \
+    "EUDI_VERIFIER_BASE_URL=${EUDI_VERIFIER_BASE_URL:-https://verifier-backend.eudiw.dev}" \
     "EUDI_VERIFIER_SCHEME=${EUDI_VERIFIER_SCHEME:-openid4vp://}" \
     "EUDI_VERIFIER_PROFILE=${EUDI_VERIFIER_PROFILE:-openid4vp}" \
     "EUDI_PID_DOCTYPE=${EUDI_PID_DOCTYPE:-eu.europa.ec.eudi.pid.1}" \

--- a/ui/src/lib/eudi-verifier.ts
+++ b/ui/src/lib/eudi-verifier.ts
@@ -1,7 +1,8 @@
 /**
  * Adapter for the EU reference OpenID4VP Verifier backend
  * (eu-digital-identity-wallet/eudi-srv-web-verifier-endpoint-23220-4-kt),
- * as hosted at https://verifier.eudiw.dev.
+ * as hosted at https://verifier-backend.eudiw.dev (the REST backend; the
+ * verifier.eudiw.dev host is the frontend UI and returns 405 on the API paths).
  *
  * Contract pinned against the reference backend README:
  *   - POST /ui/presentations           — initialise a cross-device transaction
@@ -19,7 +20,7 @@ import { randomUUID } from "crypto";
 import type { VerifiedPid } from "@/lib/eudi-patient-map";
 
 const BASE = (
-  process.env.EUDI_VERIFIER_BASE_URL ?? "https://verifier.eudiw.dev"
+  process.env.EUDI_VERIFIER_BASE_URL ?? "https://verifier-backend.eudiw.dev"
 ).replace(/\/+$/, "");
 /** QR / wallet deep-link scheme. EU reference wallet historically uses openid4vp://; haip-vp:// and eudi-openid4vp:// are alternatives. */
 const SCHEME = process.env.EUDI_VERIFIER_SCHEME ?? "openid4vp://";


### PR DESCRIPTION
`verifier.eudiw.dev` is the verifier **frontend** (nginx 405 on `POST /ui/presentations`); the REST backend is **`verifier-backend.eudiw.dev`** (same `-backend` split as `issuer-backend.eudiw.dev`). Verified: `POST` → 200 with `transaction_id` + `request_uri`. Fixes the live 502 on `/api/auth/eudi/start` (already hotfixed on the live ACA env via `az`; this makes it permanent across deploys). Follows #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)