### PR TITLE
feat(journey): simulated EUDI Wallet flow next to the QR

### DIFF
--- a/ui/__tests__/unit/components/WalletSimulation.test.tsx
+++ b/ui/__tests__/unit/components/WalletSimulation.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { WalletSimulation } from "@/components/WalletSimulation";
+
+afterEach(() => vi.useRealTimers());
+
+describe("WalletSimulation", () => {
+  it("auto-cycles through trust → review → success → loop", () => {
+    vi.useFakeTimers();
+    render(<WalletSimulation />);
+
+    // step 0 — trust the verifier
+    expect(screen.getByText(/Do you trust EHDS/i)).toBeInTheDocument();
+    expect(screen.getByText(/Verified organization/i)).toBeInTheDocument();
+    expect(screen.getByText("Yes, continue")).toBeInTheDocument();
+
+    // step 1 — review & share the PID
+    act(() => {
+      vi.advanceTimersByTime(3300);
+    });
+    expect(screen.getByText(/Review the request/i)).toBeInTheDocument();
+    expect(screen.getByText(/Person Identification Data/i)).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+
+    // step 2 — success
+    act(() => {
+      vi.advanceTimersByTime(3700);
+    });
+    expect(screen.getByText(/Success/i)).toBeInTheDocument();
+    expect(screen.getByText("Go to wallet")).toBeInTheDocument();
+
+    // loops back to step 0
+    act(() => {
+      vi.advanceTimersByTime(2700);
+    });
+    expect(screen.getByText(/Do you trust EHDS/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/app/auth/eudi-qr/page.tsx
+++ b/ui/src/app/auth/eudi-qr/page.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle2,
   AlertTriangle,
 } from "lucide-react";
+import { WalletSimulation } from "@/components/WalletSimulation";
 
 const IS_STATIC = process.env.NEXT_PUBLIC_STATIC_EXPORT === "true";
 const POLL_MS = 2000;
@@ -101,90 +102,102 @@ function EudiQrContent() {
 
   return (
     <div className="min-h-[60vh] flex flex-col items-center justify-center gap-6 py-10 px-4">
-      <div className="bg-[var(--surface-2)] rounded-lg p-8 max-w-md w-full text-center">
-        <ShieldCheck
-          size={44}
-          className="mx-auto mb-3 text-blue-800 dark:text-blue-300"
-        />
-        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">
-          Sign in with your EUDI Wallet
-        </h1>
-        <p className="text-[var(--text-secondary)] text-sm mb-6">
-          Scan the QR code with your EU Digital Identity Wallet to verify your
-          identity (OpenID4VP).
-          <br />
-          <span className="text-xs">
-            Synthetic demo · maps to a demo patient
-          </span>
-        </p>
+      <div className="flex flex-col lg:flex-row items-center justify-center gap-6 w-full max-w-4xl">
+        <div className="bg-[var(--surface-2)] rounded-lg p-8 max-w-md w-full text-center">
+          <ShieldCheck
+            size={44}
+            className="mx-auto mb-3 text-blue-800 dark:text-blue-300"
+          />
+          <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">
+            Sign in with your EUDI Wallet
+          </h1>
+          <p className="text-[var(--text-secondary)] text-sm mb-6">
+            Scan the QR code with your EU Digital Identity Wallet to verify your
+            identity (OpenID4VP).
+            <br />
+            <span className="text-xs">
+              Synthetic demo · maps to a demo patient
+            </span>
+          </p>
 
-        {phase === "loading" && (
-          <div className="py-10 text-[var(--text-secondary)]">
-            Preparing a secure request…
-          </div>
-        )}
+          {phase === "loading" && (
+            <div className="py-10 text-[var(--text-secondary)]">
+              Preparing a secure request…
+            </div>
+          )}
 
-        {phase === "scanning" && qr && (
-          <>
-            <div className="bg-white rounded-lg p-4 inline-block mb-4">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={qr}
-                alt="EUDI Wallet OpenID4VP QR code"
-                width={256}
-                height={256}
-                className="block"
+          {phase === "scanning" && qr && (
+            <>
+              <div className="bg-white rounded-lg p-4 inline-block mb-4">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={qr}
+                  alt="EUDI Wallet OpenID4VP QR code"
+                  width={256}
+                  height={256}
+                  className="block"
+                />
+              </div>
+              <div className="flex items-center justify-center gap-2 text-sm text-[var(--text-secondary)] mb-3">
+                <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                Waiting for your wallet…
+              </div>
+              {walletLink && (
+                <a
+                  href={walletLink}
+                  className="text-xs text-[var(--accent)] underline break-all"
+                >
+                  On this phone? Tap to open your wallet
+                </a>
+              )}
+            </>
+          )}
+
+          {phase === "completed" && (
+            <div className="py-8 flex flex-col items-center gap-2 text-green-600 dark:text-green-400">
+              <CheckCircle2 size={40} />
+              <p className="font-medium">Verified — signing you in…</p>
+            </div>
+          )}
+
+          {(phase === "error" || phase === "expired") && (
+            <div className="py-6">
+              <AlertTriangle
+                size={36}
+                className="mx-auto mb-2 text-amber-500"
               />
-            </div>
-            <div className="flex items-center justify-center gap-2 text-sm text-[var(--text-secondary)] mb-3">
-              <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              Waiting for your wallet…
-            </div>
-            {walletLink && (
-              <a
-                href={walletLink}
-                className="text-xs text-[var(--accent)] underline break-all"
+              <p className="text-sm text-[var(--text-secondary)] mb-4">
+                {phase === "expired"
+                  ? "This sign-in request expired."
+                  : "Could not reach the EUDI verifier."}
+              </p>
+              <button
+                onClick={start}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white dark:text-gray-900 rounded-lg font-medium transition-colors"
               >
-                On this phone? Tap to open your wallet
-              </a>
-            )}
-          </>
-        )}
+                <RefreshCw size={16} /> Try again
+              </button>
+            </div>
+          )}
 
-        {phase === "completed" && (
-          <div className="py-8 flex flex-col items-center gap-2 text-green-600 dark:text-green-400">
-            <CheckCircle2 size={40} />
-            <p className="font-medium">Verified — signing you in…</p>
-          </div>
-        )}
+          {phase === "unavailable" && (
+            <div className="py-8 text-sm text-[var(--text-secondary)]">
+              EUDI Wallet sign-in is only available on the live deployment, not
+              in the static demo. Use the demo personas on the{" "}
+              <a href="/auth/signin" className="text-[var(--accent)] underline">
+                sign-in page
+              </a>{" "}
+              instead.
+            </div>
+          )}
+        </div>
 
-        {(phase === "error" || phase === "expired") && (
-          <div className="py-6">
-            <AlertTriangle size={36} className="mx-auto mb-2 text-amber-500" />
-            <p className="text-sm text-[var(--text-secondary)] mb-4">
-              {phase === "expired"
-                ? "This sign-in request expired."
-                : "Could not reach the EUDI verifier."}
-            </p>
-            <button
-              onClick={start}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white dark:text-gray-900 rounded-lg font-medium transition-colors"
-            >
-              <RefreshCw size={16} /> Try again
-            </button>
-          </div>
-        )}
-
-        {phase === "unavailable" && (
-          <div className="py-8 text-sm text-[var(--text-secondary)]">
-            EUDI Wallet sign-in is only available on the live deployment, not in
-            the static demo. Use the demo personas on the{" "}
-            <a href="/auth/signin" className="text-[var(--accent)] underline">
-              sign-in page
-            </a>{" "}
-            instead.
-          </div>
-        )}
+        <div className="flex flex-col items-center gap-2 shrink-0">
+          <WalletSimulation />
+          <p className="text-xs text-[var(--text-secondary)] max-w-[280px] text-center">
+            What happens on your phone — a simulated wallet approval
+          </p>
+        </div>
       </div>
 
       <a

--- a/ui/src/app/journey/page.tsx
+++ b/ui/src/app/journey/page.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
+import { WalletSimulation } from "@/components/WalletSimulation";
 import {
   type LucideIcon,
   ScanLine,
@@ -25,7 +26,6 @@ import {
   Wind,
   Salad,
   Database,
-  Fingerprint,
 } from "lucide-react";
 
 /** Per-step accent (matches the 5-layer graph palette). */
@@ -121,70 +121,39 @@ function SlideIntro() {
 /** ── Slide 1 — register via QR + EUDI Wallet ─────────────────────────────── */
 function SlideRegister() {
   return (
-    <div className="grid md:grid-cols-2 gap-8 items-center max-w-5xl mx-auto w-full">
-      <Reveal delay={140} className="flex flex-col items-center">
-        <div className="bg-white rounded-2xl p-4 shadow-lg">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={`${BASE_PATH}/journey/qr-register.png`}
-            alt="QR code to register with your EUDI Wallet"
-            width={260}
-            height={260}
-            className="block w-[clamp(180px,32vw,260px)] h-auto"
-          />
-        </div>
-        <p className="mt-4 flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)]">
-          <ScanLine size={18} style={{ color: ACCENTS[0] }} />
-          Scan to authenticate with your digital identity
-        </p>
-        <p className="text-xs text-[var(--text-secondary)] mt-1">
-          Live flow → ehds.mabu.red/auth/eudi-qr
+    <div className="max-w-5xl mx-auto w-full">
+      <Reveal>
+        <h2 className="font-extrabold text-[clamp(1.4rem,3.2vw,2.1rem)] leading-tight text-[var(--text-primary)] mb-1 text-center">
+          Register with your EUDI Wallet — no password
+        </h2>
+      </Reveal>
+      <Reveal delay={120}>
+        <p className="text-center text-sm text-[var(--text-secondary)] mb-5">
+          Scan → approve on your phone → signed in · OpenID4VP · eIDAS 2.0
         </p>
       </Reveal>
-
-      <div>
-        <Reveal>
-          <h2 className="font-extrabold text-[clamp(1.5rem,3.4vw,2.3rem)] leading-tight text-[var(--text-primary)] mb-4">
-            Register with your EUDI Wallet
-          </h2>
-        </Reveal>
-        <Reveal delay={220}>
-          <ol className="space-y-3">
-            {(
-              [
-                { t: "Maria scans the QR on the portal", Icon: Fingerprint },
-                {
-                  t: "Her EUDI Wallet (Sandbox) authenticates her",
-                  Icon: ShieldCheck,
-                },
-                {
-                  t: "The wallet returns her PID — name + pseudonym",
-                  Icon: ScanLine,
-                },
-                {
-                  t: "She is registered at ehds.mabu.red — no password",
-                  Icon: ArrowRight,
-                },
-              ] as { t: string; Icon: LucideIcon }[]
-            ).map(({ t, Icon }, i) => (
-              <li key={i} className="flex items-start gap-3">
-                <span
-                  className="grid place-items-center w-7 h-7 rounded-lg text-white shrink-0"
-                  style={{ background: ACCENTS[0] }}
-                >
-                  <Icon size={16} />
-                </span>
-                <span className="text-[clamp(0.95rem,1.9vw,1.15rem)] text-[var(--text-primary)] pt-0.5">
-                  {t}
-                </span>
-              </li>
-            ))}
-          </ol>
-        </Reveal>
-        <Reveal delay={380}>
-          <p className="mt-5 text-sm text-[var(--text-secondary)]">
-            OpenID4VP · eIDAS 2.0 · self-sovereign — no central account.
+      <div className="grid md:grid-cols-2 gap-8 items-center justify-items-center">
+        <Reveal delay={200} className="flex flex-col items-center">
+          <div className="bg-white rounded-2xl p-4 shadow-lg">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${BASE_PATH}/journey/qr-register.png`}
+              alt="QR code to register with your EUDI Wallet"
+              width={230}
+              height={230}
+              className="block w-[clamp(150px,24vw,230px)] h-auto"
+            />
+          </div>
+          <p className="mt-3 flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)]">
+            <ScanLine size={18} style={{ color: ACCENTS[0] }} />
+            Scan with your EUDI Wallet
           </p>
+          <p className="text-xs text-[var(--text-secondary)] mt-1">
+            Live flow → ehds.mabu.red/auth/eudi-qr
+          </p>
+        </Reveal>
+        <Reveal delay={340} className="flex justify-center">
+          <WalletSimulation />
         </Reveal>
       </div>
     </div>

--- a/ui/src/components/WalletSimulation.tsx
+++ b/ui/src/components/WalletSimulation.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * Simulated EUDI Wallet presentation flow (OpenID4VP), shown next to the QR so a
+ * demo can play the on-phone steps without a real device. Auto-cycles:
+ *   1) Trust the verifier (EHDS — verified, first interaction)
+ *   2) Review & share the requested PID claims (selective disclosure)
+ *   3) Success
+ * Purely illustrative; no real wallet interaction. Synthetic data only.
+ */
+import { useEffect, useState } from "react";
+import {
+  Building2,
+  BadgeCheck,
+  ArrowLeftRight,
+  CheckCircle2,
+  Wifi,
+  BatteryFull,
+  SignalHigh,
+} from "lucide-react";
+
+const ORG = "European Health Dataspace";
+const STEP_MS = [3200, 3600, 2600];
+
+function StatusBar() {
+  return (
+    <div className="flex items-center justify-between px-4 pt-2 pb-1 text-[10px] font-semibold text-gray-800">
+      <span>10:55</span>
+      <div className="flex items-center gap-1">
+        <SignalHigh size={11} />
+        <Wifi size={11} />
+        <BatteryFull size={13} />
+      </div>
+    </div>
+  );
+}
+
+function Buttons({ primary }: { primary: string }) {
+  return (
+    <div className="flex gap-2 px-3 pb-3 pt-2">
+      <div className="flex-1 text-center rounded-xl bg-gray-100 text-gray-600 text-sm font-semibold py-2.5">
+        Stop
+      </div>
+      <div className="flex-1 text-center rounded-xl bg-gray-900 text-white text-sm font-semibold py-2.5 relative">
+        {primary}
+        <span className="absolute inset-0 rounded-xl ring-2 ring-[#5b3df5]/60 animate-ping" />
+      </div>
+    </div>
+  );
+}
+
+export function WalletSimulation() {
+  const [step, setStep] = useState(0);
+  useEffect(() => {
+    const t = setTimeout(() => setStep((s) => (s + 1) % 3), STEP_MS[step]);
+    return () => clearTimeout(t);
+  }, [step]);
+
+  return (
+    <div className="w-[clamp(248px,30vw,288px)] rounded-[2rem] border-[5px] border-gray-900 bg-white shadow-2xl overflow-hidden flex flex-col">
+      <style>{`
+        @keyframes wsimReveal { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+        .wsim-step { opacity: 0; animation: wsimReveal 0.45s ease forwards; }
+      `}</style>
+      <StatusBar />
+      {/* progress bar */}
+      <div className="px-4">
+        <div className="h-1.5 rounded-full bg-gray-200 overflow-hidden">
+          <div
+            className="h-full bg-[#5b3df5] transition-all duration-500"
+            style={{ width: `${((step + 1) / 3) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      <div
+        key={step}
+        className="flex-1 px-4 pt-4 wsim-step"
+        style={{ minHeight: 312 }}
+      >
+        {step === 0 && (
+          <div className="text-center">
+            <div className="mx-auto mb-3 grid place-items-center w-14 h-14 rounded-full border border-gray-200">
+              <Building2 size={26} className="text-gray-700" />
+            </div>
+            <h4 className="font-bold text-gray-900 text-[16px] leading-tight">
+              Do you trust EHDS?
+            </h4>
+            <p className="text-[11px] text-gray-500 mt-1 mb-3">
+              {ORG} wants to request information from you.
+            </p>
+            <div className="rounded-xl bg-emerald-50 border border-emerald-200 p-2.5 flex items-center gap-2 text-left mb-2">
+              <BadgeCheck size={20} className="text-emerald-600 shrink-0" />
+              <div>
+                <p className="text-[12px] font-semibold text-gray-900">
+                  Verified organization
+                </p>
+                <p className="text-[10px] text-gray-500">
+                  EU Trust Registry · EHDS
+                </p>
+              </div>
+            </div>
+            <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 flex items-center gap-2 text-left">
+              <ArrowLeftRight size={18} className="text-gray-500 shrink-0" />
+              <div>
+                <p className="text-[12px] font-semibold text-gray-900">
+                  First-time interaction
+                </p>
+                <p className="text-[10px] text-gray-500">
+                  No previous interactions
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div>
+            <h4 className="font-bold text-gray-900 text-[17px] mb-2">
+              Review the request
+            </h4>
+            <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase">
+              Purpose
+            </p>
+            <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 text-[11px] text-gray-600 mb-3">
+              Sign in &amp; register at the EHDS patient portal.
+            </div>
+            <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase mb-1">
+              Requested card
+            </p>
+            <div className="rounded-xl overflow-hidden border border-gray-200">
+              <div className="bg-[#0b3d66] text-white text-[12px] font-bold px-3 py-2">
+                PID · Person Identification Data
+              </div>
+              <div className="grid grid-cols-2 gap-y-1.5 gap-x-2 p-3 text-[11px] text-gray-700">
+                <span>First name</span>
+                <span>Last name</span>
+                <span>Date of birth</span>
+                <span className="text-gray-400">— only these</span>
+              </div>
+            </div>
+            <p className="text-[10px] text-gray-400 mt-2 text-center">
+              Selective disclosure — nothing else is shared
+            </p>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="text-center pt-4">
+            <div className="mx-auto mb-3 grid place-items-center w-16 h-16 rounded-full bg-emerald-50">
+              <CheckCircle2 size={36} className="text-emerald-600" />
+            </div>
+            <h4 className="font-bold text-gray-900 text-[19px]">Success!</h4>
+            <p className="text-[12px] text-gray-500 mt-1.5 px-2">
+              Your identity has been shared with {ORG}. You are signed in — no
+              password.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <Buttons
+        primary={
+          step === 0 ? "Yes, continue" : step === 1 ? "Share" : "Go to wallet"
+        }
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Adds an animated phone mock-up (WalletSimulation) beside the QR on the journey Register slide + /auth/eudi-qr: Trust EHDS (verified) → Review & share PID (selective disclosure) → Success. Shows the passwordless on-phone flow for the live demo without a real device. Fake-timer unit test; coverage holds.