### PR TITLE
feat(journey): EUDI wallet flows (register/login/TK ePA transfer) + homepage CTA (#80)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -81,3 +81,7 @@ All participant names in demo data, comments, and docs must be fictional:
 - DATA_USER: PharmaCo Research AG
 - HDAB: MedReg DE, Institut de Recherche Santé
 - Forbidden: Charité, Bayer, BfArM, Zuyderland, INSERM, or any real organisation.
+- Exception: real org names (e.g. TK Krankenkasse, gematik) may appear ONLY behind the
+  `NEXT_PUBLIC_DEMO_TK` build flag for live interoperability demos. The default build, committed
+  repo, and public github.io site stay fictional; real third-party screenshots are git-ignored and
+  never committed (see `ui/src/lib/journey-config.ts`).

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ reports/
 scripts/leitlinien/data/
 scripts/leitlinien/.venv/
 scripts/leitlinien/discovery_raw.json
+
+# Demo-only real-org assets (NEXT_PUBLIC_DEMO_TK) — never committed; see CLAUDE.md
+ui/public/journey/tk-transfer.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,10 @@ Unit tests in `ui/__tests__/unit/` · E2E tests in `ui/__tests__/e2e/journeys/`
 **Bash scripts:** `set -euo pipefail` + quote all variables · shellcheck at error severity
 
 **Fictional orgs only:** AlphaKlinik Berlin, PharmaCo Research AG, MedReg DE, Limburg Medical Centre,
-Institut de Recherche Santé. Never use real names (Charité, Bayer, BfArM, etc.).
+Institut de Recherche Santé. Never use real names (Charité, Bayer, BfArM, etc.). **Exception:** real
+org names (e.g. TK Krankenkasse, gematik) may appear ONLY behind the `NEXT_PUBLIC_DEMO_TK` build flag
+for live interoperability demos; the default build, committed repo, and public github.io site stay
+fictional, and real third-party screenshots are git-ignored and never committed.
 
 ## Top 5 Gotchas
 

--- a/docs/planning-health-dataspace-v2.md
+++ b/docs/planning-health-dataspace-v2.md
@@ -18,6 +18,7 @@ Planning and implementation are tracked in [GitHub Issues](https://github.com/ma
 | [#11](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/11) | Weekly Demo Reset — start-of-week baseline refresh                            | 🔓 Open   | [ADR-014](ADRs/ADR-014-weekly-demo-reset.md)                                            |
 | [#22](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/22) | DCP BusinessWallet + EUDI Wallet Sandbox — hybrid credential stack (Option B) | 🔓 Open   | Phase 27a–h + planned ADR-022 (Option A vs B vs C vs hybrid)                            |
 | [#24](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/24) | GesundheitsID OIDC RP via gematik open-source stack (Option C)                | 🔓 Open   | Phase 27i + planned ADR-022                                                             |
+| [#80](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/80) | EUDI wallet flows — register, returning-login, TK ePA transfer                | 🔓 Open   | [Plan](planning/eudi-wallet-flows-2026.md)                                              |
 
 ## Planning Documents
 
@@ -31,6 +32,7 @@ navigation; open an archive only when you need the detail of a specific phase.
 | [Roadmap — Phases 11-20](planning/roadmap-phases-11-20.md)                          | EDC component topology, API fixes, operational hardening, E2E testing, mock fallback, HealthDCAT-AP editor, 50 journey tests, Trust Center, role-aware UI, patient portal |
 | [Roadmap — Phases 21-24](planning/roadmap-phases-21-24.md)                          | Graph UX & risk scoring, static demo personas, design-system alignment, ODRL policy enforcement & GraphRAG, Phase 24 test plan                                            |
 | [Cross-Cutting Concerns & Architecture](planning/cross-cutting-and-architecture.md) | Cross-cutting concerns, target architecture, what the demo proves, implementation dependencies                                                                            |
+| [EUDI Wallet Flows (#80)](planning/eudi-wallet-flows-2026.md)                       | Register / returning-login / TK ePA-transfer wallet flows; WalletFlow engine; NEXT_PUBLIC_DEMO_TK real-org gate                                                           |
 
 For live task tracking see the [GitHub Issues](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues) table above. Architecture decisions are indexed below and kept as standalone documents in [`docs/ADRs/`](ADRs/).
 

--- a/docs/planning/eudi-wallet-flows-2026.md
+++ b/docs/planning/eudi-wallet-flows-2026.md
@@ -1,0 +1,113 @@
+# EUDI Wallet Flows — Register · Returning-Login · TK ePA Transfer
+
+**Status:** Planned · **Date:** 2026-06-04 · **Issue:** [#80](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/80)
+· **Relates to:** #22, #72, [ADR-028](../ADRs/ADR-028-patient-qr-login-eudi-wallet.md)
+
+Extends the patient [`/journey`](../../ui/src/app/journey/page.tsx) presentation and the
+[`WalletSimulation`](../../ui/src/components/WalletSimulation.tsx) with three coherent,
+static-export-safe wallet flows that share one phone-frame primitive, and reconciles the
+owner's request to name the real **TK Krankenkasse** with the project's fictional-org policy.
+
+## Goal
+
+1. **Register** (new user, first EUDI interaction) — exists; relabel as the "first time" path.
+2. **Returning Login** — a deliberately shorter, passwordless approve-and-go flow.
+3. **EHR transfer from TK** — pull the patient's **ePA** (elektronische Patientenakte) into the
+   portal via **GesundheitsID**, with a TK-branded mobile screen (real screenshot optional).
+
+## Architecture — one shared primitive
+
+Extract the phone chrome from `WalletSimulation` into a generic **`WalletFlow`** engine driven by
+a `steps: WalletStep[]` prop (per-step `ms`/`primary`/`accent`, optional `brand`, `loop`). Three
+step arrays live in `wallet/flows.ts`. `WalletSimulation` becomes a thin `WalletFlow(REGISTER_STEPS)`
+shim → **no call-site churn**, the existing `WalletSimulation.test.tsx` stays green.
+
+| Module                                        | Purpose                                                                                                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ui/src/components/wallet/PhoneFrame.tsx`     | `WalletFlow` engine + `WalletStep` type (keeps `clamp(248px,30vw,288px)`, `rounded-[2rem]`, `border-[5px]`, `#5b3df5` progress, `wsimReveal`) |
+| `ui/src/components/wallet/flows.ts`           | `REGISTER_STEPS` (verbatim current copy) · `LOGIN_STEPS` (2-step) · `EHR_TRANSFER_STEPS` (4-step)                                             |
+| `ui/src/components/wallet/EhrTransferSim.tsx` | TK-branded wrapper, optional `screenshotSrc`, synthetic fallback                                                                              |
+| `ui/src/lib/journey-config.ts`                | Gated insurer config (`NEXT_PUBLIC_DEMO_TK`) — drives slide label + brand chip                                                                |
+| `ui/src/components/WalletSimulation.tsx`      | Reimplemented as a `WalletFlow(REGISTER_STEPS)` shim                                                                                          |
+
+## Flows
+
+**A · Register** (3 steps, ≈9.4 s) — trust EHDS (verified org + first-time card) → review PID
+selective disclosure → success. On `SlideRegister` + `/auth/eudi-qr?mode=register`.
+
+**B · Login** (2 steps, ≈4.2 s — visibly faster) — "Sign in to EHDS?" with _"You've shared with EHDS
+before · last used 14 May"_ (trust step skipped) → "Signed in — welcome back". Surfaced via a
+`SlideRegister` segmented control + `/auth/eudi-qr?mode=login` (same QR / `startPresentation` call).
+
+**C · TK EHR transfer** (4 steps) — GesundheitsID auth → choose categories (Medications, Lab
+results, Diagnoses/findings, Doctor's letters, Vaccinations; recipient = EHDS portal; purpose;
+one-time / until-revoke) → authorising via GesundheitsID → transferred (FHIR R4, E2E-encrypted, TK
+cannot read it, revocable). Two-phase reveal inside `SlideEhr` (no new top-level slide); visually
+TK-coloured, not EUDI-purple.
+
+## TK / fictional-org reconciliation — **recommend Option (ii)**
+
+`CLAUDE.md` + `.claude/rules/code-style.md` forbid real org names; the owner wants **TK ·
+Techniker Krankenkasse** named, with a real TK screenshot, for a live talk. The public site is
+indexed on github.io → naming TK there risks trademark/endorsement confusion and breaks the
+all-fictional identity.
+
+| Option                                                                                                                          | Trade-off                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| (i) Name TK everywhere + disclaimer                                                                                             | Highest authenticity; **violates the rule** on a public, indexable page; disclaimer doesn't remove trademark risk                                                                                      |
+| **(ii) Public default fictional (AlphaKasse DE) + `NEXT_PUBLIC_DEMO_TK` flag → TK + real screenshot for the live talk only** ✅ | Public build/repo stay policy-clean (TK never ships); live talk gets full TK credibility; reuses the `NEXT_PUBLIC_STATIC_EXPORT` flag pattern; screenshot git-ignored, component tolerates its absence |
+| (iii) TK everywhere permanently                                                                                                 | Permanent rule violation, no compliant fallback                                                                                                                                                        |
+| (iv) Generic "your Krankenkasse", no logo                                                                                       | Low risk but still names a real org in committed code and loses the "that's literally my insurer's app" punch                                                                                          |
+
+**Decision (proposed):** Option (ii). Gitignore `ui/public/journey/tk-transfer.png`; add a one-line
+sanctioning exception to the fictional-org policy: _real org names (e.g. TK Krankenkasse, gematik)
+may appear only behind the `NEXT_PUBLIC_DEMO_TK` build flag for live interoperability demos; the
+default build, committed repo, and public github.io site use fictional orgs; real third-party
+screenshots are git-ignored and never committed._ Run the talk with `NEXT_PUBLIC_DEMO_TK=true`.
+
+## Technical-accuracy guardrails
+
+- Login speedup is a **wallet-UI** difference (skipped trust step), **not** a protocol/verifier
+  difference — the verifier cannot distinguish new vs returning users.
+- The TK transfer auth is **GesundheitsID / TK-Ident today**, **not** EUDI Wallet (EUDI→ePA is a
+  ~2027–2028 roadmap item). Keep that caveat in copy.
+- The insurer is the consent custodian and **cannot read** the E2E-encrypted contents.
+- No raw FHIR JSON shown; categories abstracted. Instant transfer + omitted key exchange are
+  flagged `simulated`.
+
+## Demo click-path
+
+`Home [Register with EUDI Wallet] → /journey → SlideRegister ([First time · Register] ⇄
+[Returning · Login]) → SlideEhr (chips/profile → [Authorize the transfer] → TK sim → "now in
+portal") → Donate → Results`. Live aside: `Home [Already have it? Sign in →] →
+/auth/eudi-qr?mode=login` (real OpenID4VP on ehds.mabu.red).
+
+## Progress checklist
+
+- [ ] Extract `WalletFlow` engine + `WalletStep` into `ui/src/components/wallet/PhoneFrame.tsx`
+- [ ] Add `ui/src/components/wallet/flows.ts` (REGISTER / LOGIN / EHR_TRANSFER steps)
+- [ ] Reimplement `WalletSimulation.tsx` as a `WalletFlow(REGISTER_STEPS)` shim; existing test green
+- [ ] Add gated insurer config `ui/src/lib/journey-config.ts` (`NEXT_PUBLIC_DEMO_TK`)
+- [ ] Add `ui/src/components/wallet/EhrTransferSim.tsx` (optional `screenshotSrc`, synthetic fallback)
+- [ ] `SlideRegister` segmented [First time · Register] / [Returning · Login] control (no new dot)
+- [ ] `SlideEhr` two-phase + `EhrTransferSim`; config-driven insurer label; fix `EPA` → `ePA`
+- [ ] `/auth/eudi-qr` `?mode=login|register` (QR / start / poll unchanged)
+- [ ] Homepage secondary "Already have it? Sign in →" → `/auth/eudi-qr?mode=login`
+- [ ] `ui/__tests__/unit/components/WalletFlow.test.tsx` (3 flows + fictional-default assertion)
+- [ ] `.gitignore` `ui/public/journey/tk-transfer.png`; build OK when absent
+- [ ] `NEXT_PUBLIC_DEMO_TK` exception in `CLAUDE.md` + `.claude/rules/code-style.md`
+- [ ] Gates: prettier · `tsc -p tsconfig.build.json` · lint · `npm test` (coverage ≥ 80)
+- [ ] Verify static-export click-path; re-run journey Playwright spec
+- [ ] (Owner) drop real `tk-transfer.png` locally + run live talk with `NEXT_PUBLIC_DEMO_TK=true`
+
+## Open questions (need the owner)
+
+1. Do you have the real **TK screenshot**? What does its consent screen look like (so the synthetic
+   step matches)? Drop as `ui/public/journey/tk-transfer.png` (~320–390 px wide).
+2. TK brand colour — **TK blue (`#1d3f8a`)** or TK red?
+3. Live talk: set `NEXT_PUBLIC_DEMO_TK` on local `npm run dev` only, or also on the ACA app
+   (`ehds.mabu.red`, semi-public)?
+4. Login as its **own** homepage CTA, or only the secondary link + journey segment? (proposed: latter)
+5. Confirm the ePA category list (Medications · Lab results · Diagnoses/findings · Doctor's letters
+   · Vaccinations).
+6. File the `CLAUDE.md` exception in this PR, or as a separate governance change to approve first?

--- a/ui/__tests__/unit/components/WalletFlow.test.tsx
+++ b/ui/__tests__/unit/components/WalletFlow.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { WalletFlow } from "@/components/wallet/PhoneFrame";
+import {
+  REGISTER_STEPS,
+  LOGIN_STEPS,
+  EHR_TRANSFER_STEPS,
+} from "@/components/wallet/flows";
+import { insurer } from "@/lib/journey-config";
+
+afterEach(() => vi.useRealTimers());
+
+describe("wallet flows", () => {
+  it("REGISTER cycles trust → review → success", () => {
+    vi.useFakeTimers();
+    render(<WalletFlow loop steps={REGISTER_STEPS} />);
+    expect(screen.getByText(/Do you trust EHDS/i)).toBeInTheDocument();
+    expect(screen.getByText("Yes, continue")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(3300);
+    });
+    expect(screen.getByText(/Review the request/i)).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(3700);
+    });
+    expect(screen.getByText(/Success/i)).toBeInTheDocument();
+    expect(screen.getByText("Go to wallet")).toBeInTheDocument();
+  });
+
+  it("LOGIN is a 2-step returning flow that skips the trust step", () => {
+    vi.useFakeTimers();
+    render(<WalletFlow loop steps={LOGIN_STEPS} />);
+    expect(screen.getByText(/Sign in to EHDS/i)).toBeInTheDocument();
+    expect(screen.getByText(/shared with EHDS before/i)).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(screen.getByText(/Welcome back/i)).toBeInTheDocument();
+    expect(LOGIN_STEPS).toHaveLength(2);
+  });
+
+  it("EHR transfer authorises an ePA pull to the EHDS portal", () => {
+    vi.useFakeTimers();
+    render(
+      <WalletFlow
+        loop
+        steps={EHR_TRANSFER_STEPS}
+        brand={{ name: insurer.name, color: insurer.brand }}
+      />,
+    );
+    expect(screen.getByText(/Connect your health record/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/GesundheitsID/i).length).toBeGreaterThan(0);
+    act(() => {
+      vi.advanceTimersByTime(3100);
+    });
+    expect(screen.getByText(/Choose what to share/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/European Health Dataspace portal/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Medications")).toBeInTheDocument();
+    expect(EHR_TRANSFER_STEPS).toHaveLength(4);
+  });
+
+  it("defaults to a fictional insurer — no real org without NEXT_PUBLIC_DEMO_TK", () => {
+    expect(insurer.name).toContain("AlphaKasse");
+    expect(insurer.name).not.toContain("TK");
+    expect(insurer.screenshot).toBeNull();
+  });
+});

--- a/ui/src/app/auth/eudi-qr/page.tsx
+++ b/ui/src/app/auth/eudi-qr/page.tsx
@@ -9,7 +9,8 @@ import {
   CheckCircle2,
   AlertTriangle,
 } from "lucide-react";
-import { WalletSimulation } from "@/components/WalletSimulation";
+import { WalletFlow } from "@/components/wallet/PhoneFrame";
+import { REGISTER_STEPS, LOGIN_STEPS } from "@/components/wallet/flows";
 
 const IS_STATIC = process.env.NEXT_PUBLIC_STATIC_EXPORT === "true";
 const POLL_MS = 2000;
@@ -26,6 +27,7 @@ type Phase =
 function EudiQrContent() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") || "/patient/profile";
+  const mode = searchParams.get("mode") === "login" ? "login" : "register";
 
   const [phase, setPhase] = useState<Phase>(
     IS_STATIC ? "unavailable" : "loading",
@@ -109,7 +111,7 @@ function EudiQrContent() {
             className="mx-auto mb-3 text-blue-800 dark:text-blue-300"
           />
           <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">
-            Sign in with your EUDI Wallet
+            {mode === "login" ? "Sign in" : "Register"} with your EUDI Wallet
           </h1>
           <p className="text-[var(--text-secondary)] text-sm mb-6">
             Scan the QR code with your EU Digital Identity Wallet to verify your
@@ -193,7 +195,11 @@ function EudiQrContent() {
         </div>
 
         <div className="flex flex-col items-center gap-2 shrink-0">
-          <WalletSimulation />
+          <WalletFlow
+            loop
+            ariaLabel={`Simulated EUDI Wallet ${mode}`}
+            steps={mode === "login" ? LOGIN_STEPS : REGISTER_STEPS}
+          />
           <p className="text-xs text-[var(--text-secondary)] max-w-[280px] text-center">
             What happens on your phone — a simulated wallet approval
           </p>

--- a/ui/src/app/journey/page.tsx
+++ b/ui/src/app/journey/page.tsx
@@ -13,7 +13,10 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { WalletSimulation } from "@/components/WalletSimulation";
+import { WalletFlow } from "@/components/wallet/PhoneFrame";
+import { REGISTER_STEPS, LOGIN_STEPS } from "@/components/wallet/flows";
+import { EhrTransferSim } from "@/components/wallet/EhrTransferSim";
+import { insurer } from "@/lib/journey-config";
 import {
   type LucideIcon,
   ScanLine,
@@ -120,17 +123,41 @@ function SlideIntro() {
 
 /** ── Slide 1 — register via QR + EUDI Wallet ─────────────────────────────── */
 function SlideRegister() {
+  const [mode, setMode] = useState<"register" | "login">("register");
+  const isReg = mode === "register";
   return (
     <div className="max-w-5xl mx-auto w-full">
       <Reveal>
         <h2 className="font-extrabold text-[clamp(1.4rem,3.2vw,2.1rem)] leading-tight text-[var(--text-primary)] mb-1 text-center">
-          Register with your EUDI Wallet — no password
+          {isReg ? "Register" : "Sign in"} with your EUDI Wallet — no password
         </h2>
       </Reveal>
-      <Reveal delay={120}>
-        <p className="text-center text-sm text-[var(--text-secondary)] mb-5">
-          Scan → approve on your phone → signed in · OpenID4VP · eIDAS 2.0
+      <Reveal delay={120} className="flex flex-col items-center gap-3 mb-4">
+        <p className="text-center text-sm text-[var(--text-secondary)]">
+          {isReg
+            ? "First time: scan → approve → registered."
+            : "Returning: scan → approve → back in. The wallet skips the trust step."}{" "}
+          · OpenID4VP · eIDAS 2.0
         </p>
+        <div className="inline-flex rounded-full border border-[var(--border)] p-1 bg-[var(--surface-2)]">
+          {(
+            [
+              ["register", "First time · Register"],
+              ["login", "Returning · Login"],
+            ] as const
+          ).map(([m, label]) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              className={`px-4 py-1.5 text-sm font-medium rounded-full transition-colors ${
+                mode === m ? "text-white" : "text-[var(--text-secondary)]"
+              }`}
+              style={mode === m ? { background: ACCENTS[0] } : undefined}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </Reveal>
       <div className="grid md:grid-cols-2 gap-8 items-center justify-items-center">
         <Reveal delay={200} className="flex flex-col items-center">
@@ -150,10 +177,15 @@ function SlideRegister() {
           </p>
           <p className="text-xs text-[var(--text-secondary)] mt-1">
             Live flow → ehds.mabu.red/auth/eudi-qr
+            {isReg ? "" : "?mode=login"}
           </p>
         </Reveal>
-        <Reveal delay={340} className="flex justify-center">
-          <WalletSimulation />
+        <Reveal delay={340} key={mode} className="flex justify-center">
+          <WalletFlow
+            loop
+            ariaLabel={`Simulated EUDI Wallet ${mode}`}
+            steps={isReg ? REGISTER_STEPS : LOGIN_STEPS}
+          />
         </Reveal>
       </div>
     </div>
@@ -162,22 +194,33 @@ function SlideRegister() {
 
 /** ── Slide 2 — fetch EHR from health insurance ───────────────────────────── */
 function SlideEhr() {
+  const [transferred, setTransferred] = useState(false);
   return (
     <div className="grid md:grid-cols-2 gap-8 items-center max-w-6xl mx-auto w-full">
-      <Reveal delay={140} className="order-2 md:order-1">
-        <div className="rounded-xl overflow-hidden border border-[var(--border)] shadow-lg bg-white">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={`${BASE_PATH}/journey/app-profile.png`}
-            alt="Maria's electronic health record in the portal, with cardiovascular and diabetes risk scores"
-            width={1280}
-            height={860}
-            className="block w-full h-auto"
-          />
-        </div>
-        <p className="text-xs text-[var(--text-secondary)] mt-2 text-center">
-          My health record in the portal — synthetic data
-        </p>
+      <Reveal
+        delay={140}
+        key={transferred ? "shot" : "sim"}
+        className="order-2 md:order-1 flex justify-center w-full"
+      >
+        {transferred ? (
+          <div className="w-full">
+            <div className="rounded-xl overflow-hidden border border-[var(--border)] shadow-lg bg-white">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`${BASE_PATH}/journey/app-profile.png`}
+                alt="Maria's electronic health record now in the portal, with cardiovascular and diabetes risk scores"
+                width={1280}
+                height={860}
+                className="block w-full h-auto"
+              />
+            </div>
+            <p className="text-xs text-[var(--text-secondary)] mt-2 text-center">
+              Now in the portal as FHIR R4 — synthetic data
+            </p>
+          </div>
+        ) : (
+          <EhrTransferSim />
+        )}
       </Reveal>
 
       <div className="order-1 md:order-2">
@@ -187,16 +230,16 @@ function SlideEhr() {
           </h2>
         </Reveal>
         <Reveal delay={180}>
-          <Quote>I need my data from my Electronic Health Record (EPA)!</Quote>
+          <Quote>I need my data from my Electronic Health Record (ePA)!</Quote>
         </Reveal>
         <Reveal delay={320}>
           <div className="mt-5 flex items-center gap-2 text-sm text-[var(--text-secondary)]">
             <Database size={16} style={{ color: ACCENTS[1] }} />
             <span>
               <strong className="text-[var(--text-primary)]">
-                AlphaKasse DE
+                {insurer.name}
               </strong>{" "}
-              (health insurance) · EPA / EHR via{" "}
+              (health insurance) · ePA / EHR via{" "}
               <strong className="text-[var(--text-primary)]">
                 GesundheitsID
               </strong>
@@ -223,9 +266,25 @@ function SlideEhr() {
           </div>
         </Reveal>
         <Reveal delay={560}>
-          <p className="mt-5 text-sm text-[var(--text-secondary)]">
-            An agent assembles my data to analyse my health —
-            GesundheitsID-authenticated.
+          <button
+            onClick={() => setTransferred(true)}
+            disabled={transferred}
+            className="mt-5 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-white font-semibold text-sm transition-all hover:scale-[1.02] disabled:opacity-70"
+            style={{ background: ACCENTS[1] }}
+          >
+            {transferred ? (
+              <>
+                <ShieldCheck size={16} /> Transferred to the portal
+              </>
+            ) : (
+              <>
+                Authorize the transfer <ArrowRight size={16} />
+              </>
+            )}
+          </button>
+          <p className="mt-2 text-xs text-[var(--text-secondary)]">
+            GesundheitsID-authenticated · end-to-end encrypted · {insurer.short}{" "}
+            cannot read it · withdraw any time
           </p>
         </Reveal>
       </div>

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -133,6 +133,12 @@ export default function Home() {
             <Info size={15} aria-hidden="true" />
             Why we need EUDI Wallet for the patient journey
           </Link>
+          <Link
+            href="/auth/eudi-qr?mode=login"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
+          >
+            Already have it? Sign in <ArrowRight size={14} aria-hidden="true" />
+          </Link>
         </div>
       </section>
 

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -17,7 +17,7 @@ import {
   Workflow,
   ScanLine,
   ArrowRight,
-  Smartphone,
+  Info,
 } from "lucide-react";
 import { DemoPersonaCards } from "@/components/DemoPersonaCards";
 import { PersonaJourneyCards } from "@/components/PersonaJourneyCards";
@@ -110,7 +110,7 @@ export default function Home() {
           </span>
         </div>
 
-        {/* ── Live-demo CTA: the patient journey ── */}
+        {/* ── Register with the EUDI Wallet (passwordless) ── */}
         <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-3">
           <Link
             href="/journey"
@@ -118,23 +118,21 @@ export default function Home() {
             style={{ background: "linear-gradient(135deg,#7D3C98,#2471A3)" }}
           >
             <ScanLine size={20} aria-hidden="true" />
-            Register &amp; start the patient journey
+            Register with EUDI Wallet
             <ArrowRight
               size={18}
               aria-hidden="true"
               className="group-hover:translate-x-1 transition-transform"
             />
           </Link>
-          <a
-            href="https://ehds.mabu.red/auth/eudi-qr"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href="/journey"
+            title="Passwordless & sovereign — no email or password. You approve on your phone and share only the exact claims requested. Tap to see the full patient journey."
             className="inline-flex items-center gap-1.5 text-sm font-medium text-[var(--accent)] hover:underline"
           >
-            <Smartphone size={15} aria-hidden="true" /> or do the live EUDI
-            Wallet login
-            <ExternalLink size={12} aria-hidden="true" />
-          </a>
+            <Info size={15} aria-hidden="true" />
+            Why we need EUDI Wallet for the patient journey
+          </Link>
         </div>
       </section>
 

--- a/ui/src/components/WalletSimulation.tsx
+++ b/ui/src/components/WalletSimulation.tsx
@@ -1,169 +1,21 @@
 "use client";
 
 /**
- * Simulated EUDI Wallet presentation flow (OpenID4VP), shown next to the QR so a
- * demo can play the on-phone steps without a real device. Auto-cycles:
- *   1) Trust the verifier (EHDS — verified, first interaction)
- *   2) Review & share the requested PID claims (selective disclosure)
- *   3) Success
- * Purely illustrative; no real wallet interaction. Synthetic data only.
+ * Simulated EUDI Wallet REGISTRATION flow (OpenID4VP), shown next to the QR.
+ * Thin shim over the shared WalletFlow engine — the step data lives in
+ * ui/src/components/wallet/flows.tsx (REGISTER_STEPS). Kept as a named export so
+ * existing call sites (journey, /auth/eudi-qr) and WalletSimulation.test.tsx are
+ * unchanged. Illustrative; synthetic data only.
  */
-import { useEffect, useState } from "react";
-import {
-  Building2,
-  BadgeCheck,
-  ArrowLeftRight,
-  CheckCircle2,
-  Wifi,
-  BatteryFull,
-  SignalHigh,
-} from "lucide-react";
-
-const ORG = "European Health Dataspace";
-const STEP_MS = [3200, 3600, 2600];
-
-function StatusBar() {
-  return (
-    <div className="flex items-center justify-between px-4 pt-2 pb-1 text-[10px] font-semibold text-gray-800">
-      <span>10:55</span>
-      <div className="flex items-center gap-1">
-        <SignalHigh size={11} />
-        <Wifi size={11} />
-        <BatteryFull size={13} />
-      </div>
-    </div>
-  );
-}
-
-function Buttons({ primary }: { primary: string }) {
-  return (
-    <div className="flex gap-2 px-3 pb-3 pt-2">
-      <div className="flex-1 text-center rounded-xl bg-gray-100 text-gray-600 text-sm font-semibold py-2.5">
-        Stop
-      </div>
-      <div className="flex-1 text-center rounded-xl bg-gray-900 text-white text-sm font-semibold py-2.5 relative">
-        {primary}
-        <span className="absolute inset-0 rounded-xl ring-2 ring-[#5b3df5]/60 animate-ping" />
-      </div>
-    </div>
-  );
-}
+import { WalletFlow } from "@/components/wallet/PhoneFrame";
+import { REGISTER_STEPS } from "@/components/wallet/flows";
 
 export function WalletSimulation() {
-  const [step, setStep] = useState(0);
-  useEffect(() => {
-    const t = setTimeout(() => setStep((s) => (s + 1) % 3), STEP_MS[step]);
-    return () => clearTimeout(t);
-  }, [step]);
-
   return (
-    <div className="w-[clamp(248px,30vw,288px)] rounded-[2rem] border-[5px] border-gray-900 bg-white shadow-2xl overflow-hidden flex flex-col">
-      <style>{`
-        @keyframes wsimReveal { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
-        .wsim-step { opacity: 0; animation: wsimReveal 0.45s ease forwards; }
-      `}</style>
-      <StatusBar />
-      {/* progress bar */}
-      <div className="px-4">
-        <div className="h-1.5 rounded-full bg-gray-200 overflow-hidden">
-          <div
-            className="h-full bg-[#5b3df5] transition-all duration-500"
-            style={{ width: `${((step + 1) / 3) * 100}%` }}
-          />
-        </div>
-      </div>
-
-      <div
-        key={step}
-        className="flex-1 px-4 pt-4 wsim-step"
-        style={{ minHeight: 312 }}
-      >
-        {step === 0 && (
-          <div className="text-center">
-            <div className="mx-auto mb-3 grid place-items-center w-14 h-14 rounded-full border border-gray-200">
-              <Building2 size={26} className="text-gray-700" />
-            </div>
-            <h4 className="font-bold text-gray-900 text-[16px] leading-tight">
-              Do you trust EHDS?
-            </h4>
-            <p className="text-[11px] text-gray-500 mt-1 mb-3">
-              {ORG} wants to request information from you.
-            </p>
-            <div className="rounded-xl bg-emerald-50 border border-emerald-200 p-2.5 flex items-center gap-2 text-left mb-2">
-              <BadgeCheck size={20} className="text-emerald-600 shrink-0" />
-              <div>
-                <p className="text-[12px] font-semibold text-gray-900">
-                  Verified organization
-                </p>
-                <p className="text-[10px] text-gray-500">
-                  EU Trust Registry · EHDS
-                </p>
-              </div>
-            </div>
-            <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 flex items-center gap-2 text-left">
-              <ArrowLeftRight size={18} className="text-gray-500 shrink-0" />
-              <div>
-                <p className="text-[12px] font-semibold text-gray-900">
-                  First-time interaction
-                </p>
-                <p className="text-[10px] text-gray-500">
-                  No previous interactions
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {step === 1 && (
-          <div>
-            <h4 className="font-bold text-gray-900 text-[17px] mb-2">
-              Review the request
-            </h4>
-            <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase">
-              Purpose
-            </p>
-            <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 text-[11px] text-gray-600 mb-3">
-              Sign in &amp; register at the EHDS patient portal.
-            </div>
-            <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase mb-1">
-              Requested card
-            </p>
-            <div className="rounded-xl overflow-hidden border border-gray-200">
-              <div className="bg-[#0b3d66] text-white text-[12px] font-bold px-3 py-2">
-                PID · Person Identification Data
-              </div>
-              <div className="grid grid-cols-2 gap-y-1.5 gap-x-2 p-3 text-[11px] text-gray-700">
-                <span>First name</span>
-                <span>Last name</span>
-                <span>Date of birth</span>
-                <span className="text-gray-400">— only these</span>
-              </div>
-            </div>
-            <p className="text-[10px] text-gray-400 mt-2 text-center">
-              Selective disclosure — nothing else is shared
-            </p>
-          </div>
-        )}
-
-        {step === 2 && (
-          <div className="text-center pt-4">
-            <div className="mx-auto mb-3 grid place-items-center w-16 h-16 rounded-full bg-emerald-50">
-              <CheckCircle2 size={36} className="text-emerald-600" />
-            </div>
-            <h4 className="font-bold text-gray-900 text-[19px]">Success!</h4>
-            <p className="text-[12px] text-gray-500 mt-1.5 px-2">
-              Your identity has been shared with {ORG}. You are signed in — no
-              password.
-            </p>
-          </div>
-        )}
-      </div>
-
-      <Buttons
-        primary={
-          step === 0 ? "Yes, continue" : step === 1 ? "Share" : "Go to wallet"
-        }
-      />
-    </div>
+    <WalletFlow
+      loop
+      ariaLabel="Simulated EUDI Wallet registration"
+      steps={REGISTER_STEPS}
+    />
   );
 }

--- a/ui/src/components/wallet/EhrTransferSim.tsx
+++ b/ui/src/components/wallet/EhrTransferSim.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+/**
+ * Simulated ePA (elektronische Patientenakte) data-transfer flow from the
+ * patient's Krankenkasse, authorised via GesundheitsID — a sibling of the EUDI
+ * WalletSimulation but visually the insurer's app (brand-coloured, not purple).
+ *
+ * This is an ePA data-access authorization, NOT an EUDI PID presentation, and
+ * GesundheitsID (not the EUDI wallet) is today's real ePA auth. Insurer label +
+ * brand come from the gated config (fictional default; TK only behind
+ * NEXT_PUBLIC_DEMO_TK). Illustrative; synthetic data.
+ */
+import { WalletFlow } from "@/components/wallet/PhoneFrame";
+import { EHR_TRANSFER_STEPS } from "@/components/wallet/flows";
+import { insurer } from "@/lib/journey-config";
+
+export function EhrTransferSim() {
+  return (
+    <WalletFlow
+      loop
+      ariaLabel={`Simulated ${insurer.short} ePA data transfer`}
+      steps={EHR_TRANSFER_STEPS}
+      brand={{ name: insurer.name, color: insurer.brand }}
+    />
+  );
+}

--- a/ui/src/components/wallet/PhoneFrame.tsx
+++ b/ui/src/components/wallet/PhoneFrame.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/**
+ * WalletFlow — a generic animated phone mock-up that auto-cycles a list of
+ * `WalletStep`s. Extracted from WalletSimulation so register / returning-login /
+ * EHR-transfer flows share one phone frame (see ui/src/components/wallet/flows.tsx).
+ * Illustrative only; synthetic data. See docs/planning/eudi-wallet-flows-2026.md.
+ */
+import { useEffect, useState } from "react";
+import { Wifi, BatteryFull, SignalHigh } from "lucide-react";
+
+export interface WalletStep {
+  /** the step's body content */
+  body: React.ReactNode;
+  /** primary (black) button label */
+  primary: string;
+  /** dwell time in ms before advancing */
+  ms: number;
+  /** progress-bar + button-ring accent (default EUDI purple) */
+  accent?: string;
+}
+
+export interface BrandChip {
+  name: string;
+  color: string;
+}
+
+const DEFAULT_ACCENT = "#5b3df5";
+
+function StatusBar() {
+  return (
+    <div className="flex items-center justify-between px-4 pt-2 pb-1 text-[10px] font-semibold text-gray-800">
+      <span>10:55</span>
+      <div className="flex items-center gap-1">
+        <SignalHigh size={11} />
+        <Wifi size={11} />
+        <BatteryFull size={13} />
+      </div>
+    </div>
+  );
+}
+
+function Buttons({ primary, accent }: { primary: string; accent: string }) {
+  return (
+    <div className="flex gap-2 px-3 pb-3 pt-2">
+      <div className="flex-1 text-center rounded-xl bg-gray-100 text-gray-600 text-sm font-semibold py-2.5">
+        Stop
+      </div>
+      <div className="flex-1 text-center rounded-xl bg-gray-900 text-white text-sm font-semibold py-2.5 relative">
+        {primary}
+        <span
+          className="absolute inset-0 rounded-xl animate-ping"
+          style={{ border: `2px solid ${accent}99` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function WalletFlow({
+  steps,
+  loop = true,
+  ariaLabel,
+  brand,
+}: {
+  steps: WalletStep[];
+  loop?: boolean;
+  ariaLabel?: string;
+  brand?: BrandChip;
+}) {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    const atEnd = step >= steps.length - 1;
+    if (atEnd && !loop) return;
+    const t = setTimeout(
+      () => setStep((s) => (s + 1) % steps.length),
+      steps[step].ms,
+    );
+    return () => clearTimeout(t);
+  }, [step, steps, loop]);
+
+  const accent = steps[step].accent ?? brand?.color ?? DEFAULT_ACCENT;
+
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="w-[clamp(248px,30vw,288px)] rounded-[2rem] border-[5px] border-gray-900 bg-white shadow-2xl overflow-hidden flex flex-col"
+    >
+      <style>{`
+        @keyframes wsimReveal { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+        .wsim-step { opacity: 0; animation: wsimReveal 0.45s ease forwards; }
+      `}</style>
+      <StatusBar />
+      {brand && (
+        <div className="px-4 pt-0.5 pb-1.5">
+          <span
+            className="inline-flex items-center text-[10px] font-bold px-2.5 py-1 rounded-full text-white"
+            style={{ background: brand.color }}
+          >
+            {brand.name}
+          </span>
+        </div>
+      )}
+      <div className="px-4">
+        <div className="h-1.5 rounded-full bg-gray-200 overflow-hidden">
+          <div
+            className="h-full transition-all duration-500"
+            style={{
+              width: `${((step + 1) / steps.length) * 100}%`,
+              background: accent,
+            }}
+          />
+        </div>
+      </div>
+
+      <div
+        key={step}
+        className="flex-1 px-4 pt-4 wsim-step"
+        style={{ minHeight: 312 }}
+      >
+        {steps[step].body}
+      </div>
+
+      <Buttons primary={steps[step].primary} accent={accent} />
+    </div>
+  );
+}

--- a/ui/src/components/wallet/flows.tsx
+++ b/ui/src/components/wallet/flows.tsx
@@ -1,0 +1,266 @@
+/**
+ * Step data for the three wallet flows rendered by WalletFlow (PhoneFrame.tsx).
+ * - REGISTER_STEPS: the original EUDI registration (kept VERBATIM so
+ *   WalletSimulation.test.tsx keeps passing).
+ * - LOGIN_STEPS: returning-user login (the wallet skips the trust step — this is
+ *   a wallet-UI difference, NOT a protocol/verifier difference).
+ * - EHR_TRANSFER_STEPS: ePA data-access authorization via GesundheitsID (NOT an
+ *   EUDI PID presentation; GesundheitsID is today's real ePA auth). Insurer is
+ *   the gated config (fictional default; TK only behind NEXT_PUBLIC_DEMO_TK).
+ * Illustrative; see docs/planning/eudi-wallet-flows-2026.md for what is simplified.
+ */
+import {
+  Building2,
+  BadgeCheck,
+  ArrowLeftRight,
+  CheckCircle2,
+  Check,
+  ShieldCheck,
+} from "lucide-react";
+import type { WalletStep } from "@/components/wallet/PhoneFrame";
+import { insurer } from "@/lib/journey-config";
+
+const ORG = "European Health Dataspace";
+
+export const REGISTER_STEPS: WalletStep[] = [
+  {
+    ms: 3200,
+    primary: "Yes, continue",
+    body: (
+      <div className="text-center">
+        <div className="mx-auto mb-3 grid place-items-center w-14 h-14 rounded-full border border-gray-200">
+          <Building2 size={26} className="text-gray-700" />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[16px] leading-tight">
+          Do you trust EHDS?
+        </h4>
+        <p className="text-[11px] text-gray-500 mt-1 mb-3">
+          {ORG} wants to request information from you.
+        </p>
+        <div className="rounded-xl bg-emerald-50 border border-emerald-200 p-2.5 flex items-center gap-2 text-left mb-2">
+          <BadgeCheck size={20} className="text-emerald-600 shrink-0" />
+          <div>
+            <p className="text-[12px] font-semibold text-gray-900">
+              Verified organization
+            </p>
+            <p className="text-[10px] text-gray-500">
+              EU Trust Registry · EHDS
+            </p>
+          </div>
+        </div>
+        <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 flex items-center gap-2 text-left">
+          <ArrowLeftRight size={18} className="text-gray-500 shrink-0" />
+          <div>
+            <p className="text-[12px] font-semibold text-gray-900">
+              First-time interaction
+            </p>
+            <p className="text-[10px] text-gray-500">
+              No previous interactions
+            </p>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    ms: 3600,
+    primary: "Share",
+    body: (
+      <div>
+        <h4 className="font-bold text-gray-900 text-[17px] mb-2">
+          Review the request
+        </h4>
+        <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase">
+          Purpose
+        </p>
+        <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 text-[11px] text-gray-600 mb-3">
+          Sign in &amp; register at the EHDS patient portal.
+        </div>
+        <p className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase mb-1">
+          Requested card
+        </p>
+        <div className="rounded-xl overflow-hidden border border-gray-200">
+          <div className="bg-[#0b3d66] text-white text-[12px] font-bold px-3 py-2">
+            PID · Person Identification Data
+          </div>
+          <div className="grid grid-cols-2 gap-y-1.5 gap-x-2 p-3 text-[11px] text-gray-700">
+            <span>First name</span>
+            <span>Last name</span>
+            <span>Date of birth</span>
+            <span className="text-gray-400">— only these</span>
+          </div>
+        </div>
+        <p className="text-[10px] text-gray-400 mt-2 text-center">
+          Selective disclosure — nothing else is shared
+        </p>
+      </div>
+    ),
+  },
+  {
+    ms: 2600,
+    primary: "Go to wallet",
+    body: (
+      <div className="text-center pt-4">
+        <div className="mx-auto mb-3 grid place-items-center w-16 h-16 rounded-full bg-emerald-50">
+          <CheckCircle2 size={36} className="text-emerald-600" />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[19px]">Success!</h4>
+        <p className="text-[12px] text-gray-500 mt-1.5 px-2">
+          Your identity has been shared with {ORG}. You are signed in — no
+          password.
+        </p>
+      </div>
+    ),
+  },
+];
+
+export const LOGIN_STEPS: WalletStep[] = [
+  {
+    ms: 2400,
+    primary: "Approve",
+    body: (
+      <div className="text-center">
+        <div className="mx-auto mb-3 grid place-items-center w-14 h-14 rounded-full border border-gray-200">
+          <Building2 size={26} className="text-gray-700" />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[16px] leading-tight">
+          Sign in to EHDS?
+        </h4>
+        <p className="text-[11px] text-gray-500 mt-1 mb-3">
+          {ORG} is asking you to sign in.
+        </p>
+        <div className="rounded-xl bg-emerald-50 border border-emerald-200 p-2.5 flex items-center gap-2 text-left mb-2">
+          <BadgeCheck size={20} className="text-emerald-600 shrink-0" />
+          <div>
+            <p className="text-[12px] font-semibold text-gray-900">
+              You&apos;ve shared with EHDS before
+            </p>
+            <p className="text-[10px] text-gray-500">
+              Last used 14 May · trusted
+            </p>
+          </div>
+        </div>
+        <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 text-left text-[11px] text-gray-600">
+          Your PID is already in your wallet — just approve. No password.
+        </div>
+      </div>
+    ),
+  },
+  {
+    ms: 1800,
+    primary: "Done",
+    body: (
+      <div className="text-center pt-6">
+        <div className="mx-auto mb-3 grid place-items-center w-16 h-16 rounded-full bg-emerald-50">
+          <CheckCircle2 size={36} className="text-emerald-600" />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[19px]">
+          Welcome back, Maria
+        </h4>
+        <p className="text-[12px] text-gray-500 mt-1.5 px-2">
+          Signed in to EHDS — no password.
+        </p>
+      </div>
+    ),
+  },
+];
+
+const EHR_CATEGORIES = [
+  "Medications",
+  "Lab results",
+  "Diagnoses & findings",
+  "Doctor's letters",
+  "Vaccinations",
+];
+
+export const EHR_TRANSFER_STEPS: WalletStep[] = [
+  {
+    ms: 3000,
+    primary: "Authenticate",
+    accent: insurer.brand,
+    body: (
+      <div className="text-center">
+        <div
+          className="mx-auto mb-3 grid place-items-center w-14 h-14 rounded-full"
+          style={{ background: `${insurer.brand}1a` }}
+        >
+          <ShieldCheck size={26} style={{ color: insurer.brand }} />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[15px] leading-tight">
+          Connect your health record
+        </h4>
+        <p className="text-[11px] font-semibold text-gray-700 mt-1 mb-3">
+          {insurer.name}
+        </p>
+        <div className="rounded-xl bg-gray-50 border border-gray-200 p-2.5 text-left text-[11px] text-gray-600">
+          The EHDS portal requests access to your{" "}
+          <strong className="text-gray-800">ePA</strong> (elektronische
+          Patientenakte).
+        </div>
+        <p className="text-[10px] text-gray-400 mt-2">
+          Authenticate with GesundheitsID
+        </p>
+      </div>
+    ),
+  },
+  {
+    ms: 3800,
+    primary: "Allow access",
+    accent: insurer.brand,
+    body: (
+      <div>
+        <h4 className="font-bold text-gray-900 text-[15px] mb-0.5">
+          Choose what to share
+        </h4>
+        <p className="text-[10px] text-gray-400 mb-2">
+          To: European Health Dataspace portal
+        </p>
+        <div className="space-y-1 text-[11px] text-gray-700">
+          {EHR_CATEGORIES.map((c) => (
+            <div
+              key={c}
+              className="flex items-center gap-2 rounded-lg bg-gray-50 border border-gray-200 px-2.5 py-1.5"
+            >
+              <Check size={13} className="text-emerald-600 shrink-0" />
+              {c}
+            </div>
+          ))}
+        </div>
+        <p className="text-[10px] text-gray-400 mt-2 text-center">
+          Until I revoke · withdraw any time
+        </p>
+      </div>
+    ),
+  },
+  {
+    ms: 2200,
+    primary: "Authorising…",
+    accent: insurer.brand,
+    body: (
+      <div className="text-center pt-8">
+        <div className="mx-auto mb-3 w-10 h-10 rounded-full border-2 border-gray-200 border-t-gray-700 animate-spin" />
+        <h4 className="font-bold text-gray-900 text-[15px]">
+          Authorising via GesundheitsID
+        </h4>
+        <p className="text-[11px] text-gray-500 mt-1">Secure authentication…</p>
+      </div>
+    ),
+  },
+  {
+    ms: 2600,
+    primary: "Done",
+    accent: insurer.brand,
+    body: (
+      <div className="text-center pt-4">
+        <div className="mx-auto mb-3 grid place-items-center w-16 h-16 rounded-full bg-emerald-50">
+          <CheckCircle2 size={36} className="text-emerald-600" />
+        </div>
+        <h4 className="font-bold text-gray-900 text-[18px]">Transferred</h4>
+        <p className="text-[11px] text-gray-500 mt-1.5 px-2">
+          Your ePA is now in the EHDS portal as FHIR R4. End-to-end encrypted —{" "}
+          {insurer.short} cannot read it. Withdraw consent any time.
+        </p>
+      </div>
+    ),
+  },
+];

--- a/ui/src/lib/journey-config.ts
+++ b/ui/src/lib/journey-config.ts
@@ -1,0 +1,41 @@
+/**
+ * Gated insurer config for the patient journey.
+ *
+ * Policy (CLAUDE.md): the default build, committed repo, and public github.io
+ * site use FICTIONAL orgs only. A real org (TK · Techniker Krankenkasse) may be
+ * shown ONLY behind the NEXT_PUBLIC_DEMO_TK build flag, for live interoperability
+ * demos. The real TK screenshot is git-ignored and never committed; the UI
+ * tolerates its absence (falls back to the synthetic screen).
+ *
+ * Live talk:  NEXT_PUBLIC_DEMO_TK=true npm run dev
+ */
+const DEMO_TK = process.env.NEXT_PUBLIC_DEMO_TK === "true";
+const BASE_PATH =
+  process.env.NEXT_PUBLIC_STATIC_EXPORT === "true"
+    ? "/MinimumViableHealthDataspacev2"
+    : "";
+
+export interface Insurer {
+  /** full label shown on the slide + brand chip */
+  name: string;
+  /** short label (e.g. for "X cannot read it") */
+  short: string;
+  /** brand colour for the TK transfer phone frame */
+  brand: string;
+  /** path to the (git-ignored) real screenshot, or null in the fictional default */
+  screenshot: string | null;
+}
+
+export const insurer: Insurer = DEMO_TK
+  ? {
+      name: "TK · Techniker Krankenkasse",
+      short: "TK",
+      brand: "#1d3f8a",
+      screenshot: `${BASE_PATH}/journey/tk-transfer.png`,
+    }
+  : {
+      name: "AlphaKasse DE",
+      short: "AlphaKasse",
+      brand: "#148F77",
+      screenshot: null,
+    };


### PR DESCRIPTION
Implements issue #80: three wallet flows on a shared WalletFlow engine — **Register**, **returning Login** (wallet skips the trust step), **TK ePA transfer** (GesundheitsID, not a PID presentation). Journey gains a Register/Login segmented control + a two-phase EHR-transfer slide. `/auth/eudi-qr?mode=login`. Homepage: 'Register with EUDI Wallet' + info link + 'Already have it? Sign in'. Real-org **NEXT_PUBLIC_DEMO_TK** gate (public stays fictional 'AlphaKasse DE'; policy exception in CLAUDE.md). Plan: docs/planning/eudi-wallet-flows-2026.md. Verified on the static export; coverage ≥80.