### PR TITLE
feat(patient): personal NLQ research page + fix demo sign-out

### DIFF
--- a/ui/__tests__/unit/pages/personal-query.test.tsx
+++ b/ui/__tests__/unit/pages/personal-query.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PersonalQueryPage from "@/app/patient/query/page";
+import { personalResearchQA } from "@/lib/personal-research";
+import { setDemoPersona, clearDemoPersona } from "@/lib/use-demo-persona";
+
+afterEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+describe("Personal Research (NLQ) page", () => {
+  it("offers 3 questions and reveals an answer + trend chart from own data on click", () => {
+    render(<PersonalQueryPage />);
+    expect(personalResearchQA).toHaveLength(3);
+    const chip = screen.getByText(/increased my daily sport routine/i);
+    expect(chip).toBeInTheDocument();
+    fireEvent.click(chip);
+    expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
+    expect(screen.getByText("VO₂max")).toBeInTheDocument();
+    expect(screen.getByText("HRV")).toBeInTheDocument();
+    expect(screen.getByText(/your own data only/i)).toBeInTheDocument();
+  });
+
+  it("every Q&A is computed from the patient's own data only", () => {
+    for (const qa of personalResearchQA) {
+      expect(qa.source).toMatch(/own data only/i);
+      expect(qa.trends.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("demo persona sign-out", () => {
+  it("setDemoPersona mirrors to localStorage; clearDemoPersona clears it", () => {
+    setDemoPersona("patient1");
+    expect(localStorage.getItem("demo-persona")).toBe("patient1");
+    clearDemoPersona();
+    // localStorage cleared so lib/api.ts isPatientPersona() no longer resolves
+    // the signed-out patient's restricted record.
+    expect(localStorage.getItem("demo-persona")).toBeNull();
+  });
+});

--- a/ui/src/app/patient/page.tsx
+++ b/ui/src/app/patient/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { fetchApi } from "@/lib/api";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -14,6 +15,7 @@ import {
   ScanLine,
   ShieldCheck,
   ArrowRight,
+  Sparkles,
   type LucideIcon,
 } from "lucide-react";
 import PageIntro from "@/components/PageIntro";
@@ -379,6 +381,15 @@ export default function PatientPage() {
               />
             ))}
           </div>
+
+          <Link
+            href="/patient/query"
+            className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-[var(--accent)] hover:underline"
+          >
+            <Sparkles size={16} aria-hidden="true" />
+            Ask research questions about my own data
+            <ArrowRight size={14} aria-hidden="true" />
+          </Link>
         </section>
 
         {detailSource && (

--- a/ui/src/app/patient/query/page.tsx
+++ b/ui/src/app/patient/query/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * Personal Research — a natural-language-query page over the patient's OWN data
+ * (EHDS Art. 3 / GDPR Art. 15 primary use). Three predefined questions; clicking
+ * one reveals a synthesised answer + trend graphs computed only from the
+ * patient's own fitness / lab / nutrition records. Synthetic · illustrative.
+ */
+import { useState } from "react";
+import {
+  Sparkles,
+  Activity,
+  Salad,
+  Wind,
+  ShieldCheck,
+  type LucideIcon,
+} from "lucide-react";
+import PageIntro from "@/components/PageIntro";
+import { MetricTrendRow } from "@/components/charts/MetricTrendRow";
+import { personalResearchQA } from "@/lib/personal-research";
+
+const QA_ICON: Record<string, LucideIcon> = {
+  sport: Activity,
+  nutrition: Salad,
+  breathing: Wind,
+};
+
+export default function PersonalQueryPage() {
+  const [asked, setAsked] = useState<string[]>([]);
+  const askedQA = asked
+    .map((id) => personalResearchQA.find((q) => q.id === id))
+    .filter((q): q is (typeof personalResearchQA)[number] => Boolean(q));
+  const remaining = personalResearchQA.filter((q) => !asked.includes(q.id));
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)]">
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        <PageIntro
+          title="Personal Research"
+          icon={Sparkles}
+          description="Ask predefined questions about your own health data. Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
+          prevStep={{ href: "/patient", label: "My Health Records" }}
+          nextStep={{ href: "/patient/insights", label: "Research Insights" }}
+          infoText="This is primary use: you query your own data. It never leaves your record and is not compared against other patients. Secondary (population) research runs separately under an HDAB data permit."
+        />
+
+        {/* Conversation */}
+        <div className="space-y-5 mb-6">
+          {askedQA.length === 0 && (
+            <div className="text-center text-sm text-[var(--text-secondary)] py-8 rounded-xl border border-dashed border-[var(--border)]">
+              Pick a question below — the answer is computed from your own data.
+            </div>
+          )}
+          {askedQA.map((qa) => {
+            const Icon = QA_ICON[qa.id] ?? Sparkles;
+            return (
+              <div key={qa.id} className="space-y-2">
+                {/* question (patient) */}
+                <div className="flex justify-end">
+                  <p className="max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--accent)] text-white px-4 py-2.5 text-sm">
+                    {qa.question}
+                  </p>
+                </div>
+                {/* answer (assistant) */}
+                <div className="rounded-2xl rounded-bl-sm border border-[var(--border)] bg-[var(--surface)] p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span
+                      className="grid place-items-center w-8 h-8 rounded-lg text-white shrink-0"
+                      style={{ background: "#7D3C98" }}
+                    >
+                      <Icon size={16} />
+                    </span>
+                    <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Your data assistant
+                    </span>
+                  </div>
+                  <p className="text-sm text-[var(--text-primary)] leading-relaxed mb-3">
+                    {qa.answer}
+                  </p>
+                  <div className="grid sm:grid-cols-2 gap-2.5">
+                    {qa.trends.map((t) => (
+                      <MetricTrendRow key={t.label} s={t} />
+                    ))}
+                  </div>
+                  <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
+                    <ShieldCheck size={12} /> {qa.source}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Predefined question chips */}
+        {remaining.length > 0 && (
+          <div>
+            <p className="section-label mb-2">
+              {askedQA.length ? "Ask another" : "Try a question"}
+            </p>
+            <div className="flex flex-col gap-2">
+              {remaining.map((qa) => {
+                const Icon = QA_ICON[qa.id] ?? Sparkles;
+                return (
+                  <button
+                    key={qa.id}
+                    type="button"
+                    onClick={() => setAsked((a) => [...a, qa.id])}
+                    className="flex items-center gap-3 text-left rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3 hover:border-[var(--accent)] transition-colors"
+                  >
+                    <Icon
+                      size={16}
+                      className="shrink-0 text-[var(--accent)]"
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm text-[var(--text-primary)]">
+                      {qa.question}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -27,6 +27,7 @@ import {
   Edit3,
   Lightbulb,
   FlaskConical,
+  Sparkles,
   Menu,
   X,
 } from "lucide-react";
@@ -282,6 +283,12 @@ const myHealthGroup: NavGroup = {
       href: "/patient",
       label: "My Health Records",
       icon: User,
+      roles: ["PATIENT"],
+    },
+    {
+      href: "/patient/query",
+      label: "Personal Research",
+      icon: Sparkles,
       roles: ["PATIENT"],
     },
     {

--- a/ui/src/components/UserMenu.tsx
+++ b/ui/src/components/UserMenu.tsx
@@ -550,6 +550,13 @@ export default function UserMenu() {
                 markSessionSwitch();
                 if (IS_STATIC) {
                   clearDemoPersona();
+                  // Navigate home so the signed-out patient's data leaves the
+                  // screen (full reload → fresh, signed-out state).
+                  const base =
+                    process.env.NEXT_PUBLIC_STATIC_EXPORT === "true"
+                      ? "/MinimumViableHealthDataspacev2"
+                      : "";
+                  window.location.href = `${base}/`;
                   return;
                 }
                 // Sign out of Keycloak's SSO session too — not just the

--- a/ui/src/components/charts/MetricTrendRow.tsx
+++ b/ui/src/components/charts/MetricTrendRow.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * MetricTrendRow — a labelled trend series (value + unit + improving/declining
+ * chip + TrendChart). Reused by the personal-research NLQ answers. Pure
+ * presentational; synthetic data.
+ */
+import { TrendingUp, TrendingDown } from "lucide-react";
+import { TrendChart } from "@/components/charts/TrendChart";
+import type { TrendSeries } from "@/lib/journey-config";
+
+export function MetricTrendRow({ s }: { s: TrendSeries }) {
+  const first = s.points[0];
+  const last = s.points[s.points.length - 1];
+  const rising = last >= first;
+  const improving = rising === (s.goodDirection === "up");
+  const pct =
+    first === 0 ? 0 : Math.round(((last - first) / Math.abs(first)) * 100);
+  const Icon = rising ? TrendingUp : TrendingDown;
+  const colour = improving ? "#1E8449" : "#CA6F1E";
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3">
+      <div className="flex items-baseline justify-between gap-2 mb-1.5">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-bold text-[var(--text-primary)]">
+            {s.label}
+          </span>
+          <span className="text-base font-black text-[var(--text-primary)]">
+            {s.current}
+          </span>
+          <span className="text-xs text-[var(--text-secondary)]">{s.unit}</span>
+        </div>
+        <span
+          className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full"
+          style={{ color: colour, background: `${colour}1a` }}
+        >
+          <Icon size={12} />
+          {pct > 0 ? "+" : ""}
+          {pct}% · 3 mo
+        </span>
+      </div>
+      <TrendChart points={s.points} color={s.color} height={48} />
+    </div>
+  );
+}

--- a/ui/src/lib/personal-research.ts
+++ b/ui/src/lib/personal-research.ts
@@ -1,0 +1,53 @@
+/**
+ * Predefined personal-research questions for the patient's own data (NLQ page).
+ * Each question maps to trend series from `personalHealth` (the patient's own
+ * fitness / lab / nutrition data) — EHDS Art. 3 / GDPR Art. 15 primary use, own
+ * records only. Synthetic · illustrative.
+ */
+import { personalHealth, type TrendSeries } from "@/lib/journey-config";
+
+const fitness = personalHealth.find((s) => s.id === "fitness")!;
+const labs = personalHealth.find((s) => s.id === "labs")!;
+const nutrition = personalHealth.find((s) => s.id === "nutrition")!;
+
+export interface ResearchQA {
+  id: "sport" | "nutrition" | "breathing";
+  question: string;
+  answer: string;
+  /** provenance line — always "own data only" */
+  source: string;
+  /** trend series shown beneath the answer */
+  trends: TrendSeries[];
+}
+
+export const personalResearchQA: ResearchQA[] = [
+  {
+    id: "sport",
+    question:
+      "I increased my daily sport routine over the last 3 months — do you see any effect?",
+    answer:
+      "Yes — your cardio-fitness improved. VO₂max rose from 42 to 47 ml/kg/min and your heart-rate variability climbed, both signs of better recovery and a lower resting heart rate.",
+    source: "Computed from your fitness band — your own data only.",
+    trends: [fitness.trends[0], fitness.trends[1]],
+  },
+  {
+    id: "nutrition",
+    question:
+      "I changed my nutrition over 3 months — how are my cardiovascular and pre-diabetes markers?",
+    answer:
+      "Trending the right way — inflammation (CRP) is down and vitamin D is up, both consistent with lower cardiovascular risk. Your Mediterranean-plan adherence reached 86%.",
+    source:
+      "Computed from your lab panel and nutrition plan — your own data only.",
+    trends: [labs.trends[2], nutrition.trends[0]],
+  },
+  {
+    id: "breathing",
+    question:
+      "I've been doing daily breathing exercises — any effect on stress and inflammation?",
+    answer:
+      "Likely yes — your inflammation marker (CRP) fell from 2.1 to 0.8 mg/L this quarter and your HRV improved. Lower CRP and higher HRV both point to a reduced stress load.",
+    source:
+      "Computed from your lab panel and fitness band — your own data only.",
+    trends: [labs.trends[2], fitness.trends[1]],
+  },
+];

--- a/ui/src/lib/use-demo-persona.ts
+++ b/ui/src/lib/use-demo-persona.ts
@@ -32,6 +32,13 @@ const emitter: EventTarget | null =
 export function setDemoPersona(username: string): void {
   if (typeof sessionStorage === "undefined") return;
   sessionStorage.setItem(DEMO_PERSONA_KEY, username);
+  // Mirror to localStorage: lib/api.ts reads localStorage to resolve the
+  // restricted patient mock, so the two stores must stay in sync.
+  try {
+    localStorage.setItem(DEMO_PERSONA_KEY, username);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
   emitter?.dispatchEvent(new Event("change"));
 }
 
@@ -39,6 +46,14 @@ export function setDemoPersona(username: string): void {
 export function clearDemoPersona(): void {
   if (typeof sessionStorage === "undefined") return;
   sessionStorage.setItem(DEMO_PERSONA_KEY, SIGNED_OUT);
+  // Clear localStorage too so lib/api.ts no longer resolves the patient's own
+  // record after sign-out (otherwise /patient keeps showing the signed-out
+  // patient's data).
+  try {
+    localStorage.removeItem(DEMO_PERSONA_KEY);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
   emitter?.dispatchEvent(new Event("change"));
 }
 


### PR DESCRIPTION
Two follow-ups from the live demo:

## 1. Sign-out now fully signs the patient out
`setDemoPersona`/`clearDemoPersona` mirror to **localStorage** (which `lib/api.ts` reads to resolve the restricted patient mock — previously only sessionStorage was cleared, so `/patient` kept showing the signed-out patient's data). The static sign-out handler navigates home, so the data leaves the screen. Verified: after Sign out, `localStorage demo-persona` is null, nav shows "Sign in", `/patient` no longer shows Maria.

## 2. Personal Research (NLQ) page — own data only
New `/patient/query` in the **My Health** nav + a link on the patient record. Three predefined questions (sport→VO₂max/HRV, nutrition→CRP/adherence, breathing→CRP/HRV) reveal a synthesised answer + `TrendChart`, computed **only from the patient's own data** (EHDS Art. 3 / GDPR Art. 15 — primary use). New `MetricTrendRow` + `personal-research` config.

## Gates
tsc ✓ · eslint ✓ · 1750 unit pass (2 pre-existing timing flakes pass on `--retry`), coverage 82.16% lines · static export + sign-out + NLQ verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)