### PR TITLE
fix(journey): remove Blood Test Oracle brand image + name from labs card

### DIFF
--- a/ui/src/lib/journey-config.ts
+++ b/ui/src/lib/journey-config.ts
@@ -78,10 +78,11 @@ export const donationSources: DataSource[] = [
   },
   {
     id: "labs",
-    label: DEMO_TK ? "Blood Test Oracle" : "Lab results",
+    label: "Lab results",
     sublabel: "Ferritin · B12 · CRP · omega-3",
     brand: "#7D3C98",
-    screenshot: DEMO_TK ? `${BASE_PATH}/journey/bloodtest-labs.png` : null,
+    // No third-party lab-brand screenshot.
+    screenshot: null,
   },
 ];
 
@@ -183,9 +184,10 @@ export const personalHealth: PersonalHealthSource[] = [
   {
     id: "labs",
     title: "Lab results",
-    source: DEMO_TK ? "Blood Test Oracle" : "Lab panel",
+    source: "Lab panel",
     brand: "#7D3C98",
-    screenshot: DEMO_TK ? `${BASE_PATH}/journey/bloodtest-labs.png` : null,
+    // No third-party lab-brand screenshot — the metrics + trend charts carry it.
+    screenshot: null,
     metrics: [
       { label: "Ferritin", value: "112 ng/ml" },
       { label: "Vitamin D", value: "48 ng/ml" },


### PR DESCRIPTION
Mirrors the earlier Whoop removal — the labs source no longer references the git-ignored third-party screenshot or the 'Blood Test Oracle' brand name (now 'Lab panel'); the flask icon + metrics + trends carry it. Public/DEMO-off builds were already image-less, so this only affects the `NEXT_PUBLIC_DEMO_TK` build. Verified on :3000: no Blood Test Oracle image/text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)