### PR TITLE
feat(patient): NLQ free-text input — answer + trend after Send

### DIFF
--- a/ui/__tests__/unit/pages/personal-query.test.tsx
+++ b/ui/__tests__/unit/pages/personal-query.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import PersonalQueryPage from "@/app/patient/query/page";
-import { personalResearchQA } from "@/lib/personal-research";
+import {
+  personalResearchQA,
+  matchPersonalResearch,
+} from "@/lib/personal-research";
 import { setDemoPersona, clearDemoPersona } from "@/lib/use-demo-persona";
 
 afterEach(() => {
@@ -10,22 +13,54 @@ afterEach(() => {
 });
 
 describe("Personal Research (NLQ) page", () => {
-  it("offers 3 questions and reveals an answer + trend chart from own data on click", () => {
+  it("answers a typed free-text question only after Send, with a trend from own data", () => {
     render(<PersonalQueryPage />);
-    expect(personalResearchQA).toHaveLength(3);
-    const chip = screen.getByText(/increased my daily sport routine/i);
-    expect(chip).toBeInTheDocument();
-    fireEvent.click(chip);
+    // nothing shown before sending
+    expect(screen.queryByText(/cardio-fitness improved/i)).toBeNull();
+    const input = screen.getByLabelText(
+      /Ask a question about your own health data/i,
+    );
+    fireEvent.change(input, {
+      target: { value: "did my running and sport routine help my fitness?" },
+    });
+    fireEvent.click(screen.getByLabelText(/Send question/i));
     expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
     expect(screen.getByText("VO₂max")).toBeInTheDocument();
-    expect(screen.getByText("HRV")).toBeInTheDocument();
     expect(screen.getByText(/your own data only/i)).toBeInTheDocument();
+  });
+
+  it("a suggestion chip sends the question and reveals the answer", () => {
+    render(<PersonalQueryPage />);
+    fireEvent.click(screen.getByText(/increased my daily sport routine/i));
+    expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
+  });
+
+  it("out-of-scope questions get a graceful own-data-only fallback", () => {
+    render(<PersonalQueryPage />);
+    const input = screen.getByLabelText(
+      /Ask a question about your own health data/i,
+    );
+    fireEvent.change(input, { target: { value: "what is the weather today" } });
+    fireEvent.click(screen.getByLabelText(/Send question/i));
+    expect(
+      screen.getByText(/I can only answer from your own/i),
+    ).toBeInTheDocument();
+  });
+
+  it("matchPersonalResearch maps keywords to the right answer (or null)", () => {
+    expect(matchPersonalResearch("my running and VO2")?.id).toBe("sport");
+    expect(matchPersonalResearch("breathing and stress")?.id).toBe("breathing");
+    expect(matchPersonalResearch("nutrition and cholesterol")?.id).toBe(
+      "nutrition",
+    );
+    expect(matchPersonalResearch("hello world")).toBeNull();
   });
 
   it("every Q&A is computed from the patient's own data only", () => {
     for (const qa of personalResearchQA) {
       expect(qa.source).toMatch(/own data only/i);
       expect(qa.trends.length).toBeGreaterThan(0);
+      expect(qa.keywords.length).toBeGreaterThan(0);
     }
   });
 });
@@ -35,8 +70,6 @@ describe("demo persona sign-out", () => {
     setDemoPersona("patient1");
     expect(localStorage.getItem("demo-persona")).toBe("patient1");
     clearDemoPersona();
-    // localStorage cleared so lib/api.ts isPatientPersona() no longer resolves
-    // the signed-out patient's restricted record.
     expect(localStorage.getItem("demo-persona")).toBeNull();
   });
 });

--- a/ui/src/app/patient/query/page.tsx
+++ b/ui/src/app/patient/query/page.tsx
@@ -2,9 +2,11 @@
 
 /**
  * Personal Research — a natural-language-query page over the patient's OWN data
- * (EHDS Art. 3 / GDPR Art. 15 primary use). Three predefined questions; clicking
- * one reveals a synthesised answer + trend graphs computed only from the
- * patient's own fitness / lab / nutrition records. Synthetic · illustrative.
+ * (EHDS Art. 3 / GDPR Art. 15 primary use). Type a question (or tap a
+ * suggestion) and Send; the answer + trend graphs — computed only from the
+ * patient's own fitness / lab / nutrition records — appear in the conversation.
+ * No LLM in the static demo: free text is keyword-matched to a predefined
+ * answer. Synthetic · illustrative.
  */
 import { useState } from "react";
 import {
@@ -13,11 +15,17 @@ import {
   Salad,
   Wind,
   ShieldCheck,
+  Send,
+  Info,
   type LucideIcon,
 } from "lucide-react";
 import PageIntro from "@/components/PageIntro";
 import { MetricTrendRow } from "@/components/charts/MetricTrendRow";
-import { personalResearchQA } from "@/lib/personal-research";
+import {
+  personalResearchQA,
+  matchPersonalResearch,
+  type ResearchQA,
+} from "@/lib/personal-research";
 
 const QA_ICON: Record<string, LucideIcon> = {
   sport: Activity,
@@ -25,12 +33,34 @@ const QA_ICON: Record<string, LucideIcon> = {
   breathing: Wind,
 };
 
+interface Message {
+  role: "user" | "assistant";
+  text: string;
+  qa?: ResearchQA;
+  fallback?: boolean;
+}
+
 export default function PersonalQueryPage() {
-  const [asked, setAsked] = useState<string[]>([]);
-  const askedQA = asked
-    .map((id) => personalResearchQA.find((q) => q.id === id))
-    .filter((q): q is (typeof personalResearchQA)[number] => Boolean(q));
-  const remaining = personalResearchQA.filter((q) => !asked.includes(q.id));
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  function send(text: string) {
+    const q = text.trim();
+    if (!q) return;
+    const qa = matchPersonalResearch(q);
+    setMessages((m) => [
+      ...m,
+      { role: "user", text: q },
+      qa
+        ? { role: "assistant", text: qa.answer, qa }
+        : {
+            role: "assistant",
+            fallback: true,
+            text: "I can only answer from your own fitness, lab and nutrition records. Try asking about your sport routine, your nutrition, or your breathing exercises.",
+          },
+    ]);
+    setInput("");
+  }
 
   return (
     <div className="min-h-screen bg-[var(--bg)]">
@@ -38,89 +68,120 @@ export default function PersonalQueryPage() {
         <PageIntro
           title="Personal Research"
           icon={Sparkles}
-          description="Ask predefined questions about your own health data. Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
+          description="Ask a question about your own health data. Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
           prevStep={{ href: "/patient", label: "My Health Records" }}
           nextStep={{ href: "/patient/insights", label: "Research Insights" }}
-          infoText="This is primary use: you query your own data. It never leaves your record and is not compared against other patients. Secondary (population) research runs separately under an HDAB data permit."
+          infoText="This is primary use: you query your own data. It never leaves your record and is not compared against other patients. The static demo matches your free-text question to a predefined answer by keyword (no AI model)."
         />
 
         {/* Conversation */}
-        <div className="space-y-5 mb-6">
-          {askedQA.length === 0 && (
+        <div className="space-y-4 mb-5 min-h-[80px]">
+          {messages.length === 0 && (
             <div className="text-center text-sm text-[var(--text-secondary)] py-8 rounded-xl border border-dashed border-[var(--border)]">
-              Pick a question below — the answer is computed from your own data.
+              Type a question below — or tap a suggestion — to see an answer
+              from your own data.
             </div>
           )}
-          {askedQA.map((qa) => {
+          {messages.map((m, i) =>
+            m.role === "user" ? (
+              <div key={i} className="flex justify-end">
+                <p className="max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--accent)] text-white px-4 py-2.5 text-sm">
+                  {m.text}
+                </p>
+              </div>
+            ) : (
+              <div
+                key={i}
+                className="rounded-2xl rounded-bl-sm border border-[var(--border)] bg-[var(--surface)] p-4"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span
+                    className="grid place-items-center w-8 h-8 rounded-lg text-white shrink-0"
+                    style={{ background: m.fallback ? "#64748b" : "#7D3C98" }}
+                  >
+                    {(() => {
+                      const Icon = m.qa ? QA_ICON[m.qa.id] ?? Sparkles : Info;
+                      return <Icon size={16} />;
+                    })()}
+                  </span>
+                  <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+                    Your data assistant
+                  </span>
+                </div>
+                <p className="text-sm text-[var(--text-primary)] leading-relaxed mb-3">
+                  {m.text}
+                </p>
+                {m.qa && (
+                  <>
+                    <div className="grid sm:grid-cols-2 gap-2.5">
+                      {m.qa.trends.map((t) => (
+                        <MetricTrendRow key={t.label} s={t} />
+                      ))}
+                    </div>
+                    <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
+                      <ShieldCheck size={12} /> {m.qa.source}
+                    </p>
+                  </>
+                )}
+              </div>
+            ),
+          )}
+        </div>
+
+        {/* Suggestions */}
+        <p className="section-label mb-2">Suggested questions</p>
+        <div className="flex flex-col gap-2 mb-4">
+          {personalResearchQA.map((qa) => {
             const Icon = QA_ICON[qa.id] ?? Sparkles;
             return (
-              <div key={qa.id} className="space-y-2">
-                {/* question (patient) */}
-                <div className="flex justify-end">
-                  <p className="max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--accent)] text-white px-4 py-2.5 text-sm">
-                    {qa.question}
-                  </p>
-                </div>
-                {/* answer (assistant) */}
-                <div className="rounded-2xl rounded-bl-sm border border-[var(--border)] bg-[var(--surface)] p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <span
-                      className="grid place-items-center w-8 h-8 rounded-lg text-white shrink-0"
-                      style={{ background: "#7D3C98" }}
-                    >
-                      <Icon size={16} />
-                    </span>
-                    <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
-                      Your data assistant
-                    </span>
-                  </div>
-                  <p className="text-sm text-[var(--text-primary)] leading-relaxed mb-3">
-                    {qa.answer}
-                  </p>
-                  <div className="grid sm:grid-cols-2 gap-2.5">
-                    {qa.trends.map((t) => (
-                      <MetricTrendRow key={t.label} s={t} />
-                    ))}
-                  </div>
-                  <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
-                    <ShieldCheck size={12} /> {qa.source}
-                  </p>
-                </div>
-              </div>
+              <button
+                key={qa.id}
+                type="button"
+                onClick={() => send(qa.question)}
+                className="flex items-center gap-3 text-left rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3 hover:border-[var(--accent)] transition-colors"
+              >
+                <Icon
+                  size={16}
+                  className="shrink-0 text-[var(--accent)]"
+                  aria-hidden="true"
+                />
+                <span className="text-sm text-[var(--text-primary)]">
+                  {qa.question}
+                </span>
+              </button>
             );
           })}
         </div>
 
-        {/* Predefined question chips */}
-        {remaining.length > 0 && (
-          <div>
-            <p className="section-label mb-2">
-              {askedQA.length ? "Ask another" : "Try a question"}
-            </p>
-            <div className="flex flex-col gap-2">
-              {remaining.map((qa) => {
-                const Icon = QA_ICON[qa.id] ?? Sparkles;
-                return (
-                  <button
-                    key={qa.id}
-                    type="button"
-                    onClick={() => setAsked((a) => [...a, qa.id])}
-                    className="flex items-center gap-3 text-left rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3 hover:border-[var(--accent)] transition-colors"
-                  >
-                    <Icon
-                      size={16}
-                      className="shrink-0 text-[var(--accent)]"
-                      aria-hidden="true"
-                    />
-                    <span className="text-sm text-[var(--text-primary)]">
-                      {qa.question}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        )}
+        {/* Free-text input */}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            send(input);
+          }}
+          className="flex items-center gap-2"
+        >
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            aria-label="Ask a question about your own health data"
+            placeholder="Ask about your own health data…"
+            className="flex-1 rounded-xl border border-[var(--border-ui)] bg-[var(--surface-card)] px-4 py-3 text-sm text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+          <button
+            type="submit"
+            disabled={!input.trim()}
+            aria-label="Send question"
+            className="grid place-items-center w-12 h-12 rounded-xl text-white shrink-0 transition-all hover:scale-[1.03] disabled:opacity-40 disabled:hover:scale-100"
+            style={{ background: "var(--accent)" }}
+          >
+            <Send size={18} />
+          </button>
+        </form>
+        <p className="text-[11px] text-[var(--text-secondary)] mt-2">
+          Your own records only · synthetic · not medical advice
+        </p>
       </div>
     </div>
   );

--- a/ui/src/lib/personal-research.ts
+++ b/ui/src/lib/personal-research.ts
@@ -3,6 +3,9 @@
  * Each question maps to trend series from `personalHealth` (the patient's own
  * fitness / lab / nutrition data) — EHDS Art. 3 / GDPR Art. 15 primary use, own
  * records only. Synthetic · illustrative.
+ *
+ * The NLQ page accepts free-text questions; `matchPersonalResearch` resolves a
+ * typed question to one of these answers by keyword (no LLM in the static demo).
  */
 import { personalHealth, type TrendSeries } from "@/lib/journey-config";
 
@@ -18,6 +21,8 @@ export interface ResearchQA {
   source: string;
   /** trend series shown beneath the answer */
   trends: TrendSeries[];
+  /** keywords used to resolve a free-text question to this answer */
+  keywords: string[];
 }
 
 export const personalResearchQA: ResearchQA[] = [
@@ -29,6 +34,23 @@ export const personalResearchQA: ResearchQA[] = [
       "Yes — your cardio-fitness improved. VO₂max rose from 42 to 47 ml/kg/min and your heart-rate variability climbed, both signs of better recovery and a lower resting heart rate.",
     source: "Computed from your fitness band — your own data only.",
     trends: [fitness.trends[0], fitness.trends[1]],
+    keywords: [
+      "sport",
+      "exercise",
+      "run",
+      "running",
+      "training",
+      "workout",
+      "fitness",
+      "vo2",
+      "vo₂",
+      "cardio",
+      "heart rate",
+      "resting hr",
+      "gym",
+      "active",
+      "steps",
+    ],
   },
   {
     id: "nutrition",
@@ -39,6 +61,24 @@ export const personalResearchQA: ResearchQA[] = [
     source:
       "Computed from your lab panel and nutrition plan — your own data only.",
     trends: [labs.trends[2], nutrition.trends[0]],
+    keywords: [
+      "nutrition",
+      "diet",
+      "food",
+      "eat",
+      "eating",
+      "meal",
+      "cardiovascular",
+      "cardio risk",
+      "diabetes",
+      "pre-diabetes",
+      "prediabetes",
+      "cholesterol",
+      "ldl",
+      "weight",
+      "mediterranean",
+      "vitamin d",
+    ],
   },
   {
     id: "breathing",
@@ -49,5 +89,43 @@ export const personalResearchQA: ResearchQA[] = [
     source:
       "Computed from your lab panel and fitness band — your own data only.",
     trends: [labs.trends[2], fitness.trends[1]],
+    keywords: [
+      "breath",
+      "breathing",
+      "stress",
+      "inflammation",
+      "crp",
+      "oxygen",
+      "spo2",
+      "meditation",
+      "relax",
+      "calm",
+      "anxiety",
+      "hrv",
+      "recovery",
+    ],
   },
 ];
+
+/**
+ * Resolve a free-text question to one of the predefined answers by keyword
+ * overlap (the static demo has no LLM). Returns the best match, or null when the
+ * question is outside the patient's own fitness / lab / nutrition data.
+ */
+export function matchPersonalResearch(text: string): ResearchQA | null {
+  const t = text.toLowerCase();
+  // Word-boundary match so "run" → "running" but not "drunk", and "eat" does
+  // not match "weather".
+  const hit = (k: string) =>
+    new RegExp(`\\b${k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i").test(t);
+  let best: ResearchQA | null = null;
+  let bestHits = 0;
+  for (const qa of personalResearchQA) {
+    const hits = qa.keywords.filter(hit).length;
+    if (hits > bestHits) {
+      bestHits = hits;
+      best = qa;
+    }
+  }
+  return bestHits > 0 ? best : null;
+}


### PR DESCRIPTION
Reworks /patient/query into a chat with a free-text input + Send button (plus the 3 suggestions). Nothing shows until you send; the answer + trend graphs then appear. Free text is word-boundary keyword-matched to a predefined own-data answer (no LLM in the static demo); out-of-scope questions get an own-data-only fallback. Adds `matchPersonalResearch`.

Verified on :3000: input + Send present, no answer before send, answer + VO₂max/HRV trends after send, fallback for out-of-scope. tsc/eslint ✓, 6 NLQ tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)