### PR TITLE
feat(patient): NLQ over ePA events — infections, surgeries, vaccinations

### DIFF
--- a/ui/__tests__/unit/pages/personal-query.test.tsx
+++ b/ui/__tests__/unit/pages/personal-query.test.tsx
@@ -47,19 +47,50 @@ describe("Personal Research (NLQ) page", () => {
     ).toBeInTheDocument();
   });
 
+  it("answers an ePA question (infections) with a list of events", () => {
+    render(<PersonalQueryPage />);
+    const input = screen.getByLabelText(
+      /Ask a question about your own health data/i,
+    );
+    fireEvent.change(input, {
+      target: { value: "which infections do I have?" },
+    });
+    fireEvent.click(screen.getByLabelText(/Send question/i));
+    expect(screen.getByText(/three infections/i)).toBeInTheDocument();
+    // "Acute bronchitis" appears in both the answer and the event row
+    expect(
+      screen.getAllByText(/Acute bronchitis/i).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Infection").length).toBe(3);
+    expect(
+      screen.getByText(/elektronische Patientenakte/i),
+    ).toBeInTheDocument();
+  });
+
   it("matchPersonalResearch maps keywords to the right answer (or null)", () => {
     expect(matchPersonalResearch("my running and VO2")?.id).toBe("sport");
     expect(matchPersonalResearch("breathing and stress")?.id).toBe("breathing");
     expect(matchPersonalResearch("nutrition and cholesterol")?.id).toBe(
       "nutrition",
     );
+    expect(matchPersonalResearch("which infections have I had")?.id).toBe(
+      "infections",
+    );
+    expect(matchPersonalResearch("any surgeries or operations")?.id).toBe(
+      "surgeries",
+    );
+    expect(
+      matchPersonalResearch("am I up to date on my vaccinations")?.id,
+    ).toBe("vaccines");
     expect(matchPersonalResearch("hello world")).toBeNull();
   });
 
   it("every Q&A is computed from the patient's own data only", () => {
     for (const qa of personalResearchQA) {
       expect(qa.source).toMatch(/own data only/i);
-      expect(qa.trends.length).toBeGreaterThan(0);
+      expect(
+        (qa.trends?.length ?? 0) + (qa.events?.length ?? 0),
+      ).toBeGreaterThan(0);
       expect(qa.keywords.length).toBeGreaterThan(0);
     }
   });

--- a/ui/public/mock/patient_restricted.json
+++ b/ui/public/mock/patient_restricted.json
@@ -10,10 +10,10 @@
   "stats": {
     "patients": 1,
     "encounters": 12,
-    "conditions": 6,
+    "conditions": 9,
     "observations": 24,
     "medications": 4,
-    "procedures": 5
+    "procedures": 7
   },
   "restricted": true,
   "timeline": [
@@ -248,6 +248,78 @@
       "display": "Mild intermittent asthma",
       "omopType": "ConditionOccurrence",
       "omopId": "317009"
+    },
+    {
+      "fhirType": "Immunization",
+      "fhirId": "imm-flu-2025",
+      "date": "2025-10-15",
+      "display": "Influenza vaccine 2025/26",
+      "omopType": "DrugExposure",
+      "omopId": "40213154"
+    },
+    {
+      "fhirType": "Immunization",
+      "fhirId": "imm-flu-2024",
+      "date": "2024-10-08",
+      "display": "Influenza vaccine 2024/25",
+      "omopType": "DrugExposure",
+      "omopId": "40213154"
+    },
+    {
+      "fhirType": "Condition",
+      "fhirId": "cond-flu-2024",
+      "date": "2024-12-03",
+      "display": "Influenza (seasonal) — resolved",
+      "omopType": "ConditionOccurrence",
+      "omopId": "4266367"
+    },
+    {
+      "fhirType": "Immunization",
+      "fhirId": "imm-covid-2024",
+      "date": "2024-04-02",
+      "display": "COVID-19 mRNA booster",
+      "omopType": "DrugExposure",
+      "omopId": "724904"
+    },
+    {
+      "fhirType": "Condition",
+      "fhirId": "cond-bronchitis-2023",
+      "date": "2023-03-20",
+      "display": "Acute bronchitis — resolved",
+      "omopType": "ConditionOccurrence",
+      "omopId": "260139"
+    },
+    {
+      "fhirType": "Condition",
+      "fhirId": "cond-covid-2022",
+      "date": "2022-11-08",
+      "display": "COVID-19, mild — recovered",
+      "omopType": "ConditionOccurrence",
+      "omopId": "37311061"
+    },
+    {
+      "fhirType": "Immunization",
+      "fhirId": "imm-tdap-2021",
+      "date": "2021-05-18",
+      "display": "Tetanus-diphtheria (Td) booster",
+      "omopType": "DrugExposure",
+      "omopId": "529411"
+    },
+    {
+      "fhirType": "Procedure",
+      "fhirId": "proc-knee-2020",
+      "date": "2020-09-22",
+      "display": "Knee arthroscopy (meniscus repair)",
+      "omopType": "ProcedureOccurrence",
+      "omopId": "4006988"
+    },
+    {
+      "fhirType": "Procedure",
+      "fhirId": "proc-appendectomy-2018",
+      "date": "2018-06-14",
+      "display": "Laparoscopic appendectomy",
+      "omopType": "ProcedureOccurrence",
+      "omopId": "4232476"
     }
   ]
 }

--- a/ui/src/app/patient/page.tsx
+++ b/ui/src/app/patient/page.tsx
@@ -16,6 +16,7 @@ import {
   ShieldCheck,
   ArrowRight,
   Sparkles,
+  Syringe,
   type LucideIcon,
 } from "lucide-react";
 import PageIntro from "@/components/PageIntro";
@@ -82,6 +83,11 @@ const FHIR_TYPE_TOKENS: Record<
     text: "var(--fhir-procedure)",
     bg: "var(--role-trust-bg)",
     icon: <Scissors size={12} />,
+  },
+  Immunization: {
+    text: "var(--fhir-encounter)",
+    bg: "var(--role-holder-bg)",
+    icon: <Syringe size={12} />,
   },
 };
 

--- a/ui/src/app/patient/query/page.tsx
+++ b/ui/src/app/patient/query/page.tsx
@@ -14,6 +14,9 @@ import {
   Activity,
   Salad,
   Wind,
+  Bug,
+  Scissors,
+  Syringe,
   ShieldCheck,
   Send,
   Info,
@@ -31,6 +34,17 @@ const QA_ICON: Record<string, LucideIcon> = {
   sport: Activity,
   nutrition: Salad,
   breathing: Wind,
+  infections: Bug,
+  surgeries: Scissors,
+  vaccines: Syringe,
+};
+
+/** Badge colour per ePA event type. */
+const EPA_TYPE_COLOR: Record<string, string> = {
+  Infection: "#CA6F1E",
+  Surgery: "#2471A3",
+  Vaccination: "#1E8449",
+  Diagnosis: "#7D3C98",
 };
 
 interface Message {
@@ -68,7 +82,7 @@ export default function PersonalQueryPage() {
         <PageIntro
           title="Personal Research"
           icon={Sparkles}
-          description="Ask a question about your own health data. Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
+          description="Ask a question about your own health data — fitness, lab and nutrition trends, or your ePA record (infections, surgeries, vaccinations and more). Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
           prevStep={{ href: "/patient", label: "My Health Records" }}
           nextStep={{ href: "/patient/insights", label: "Research Insights" }}
           infoText="This is primary use: you query your own data. It never leaves your record and is not compared against other patients. The static demo matches your free-text question to a predefined answer by keyword (no AI model)."
@@ -113,11 +127,38 @@ export default function PersonalQueryPage() {
                 </p>
                 {m.qa && (
                   <>
-                    <div className="grid sm:grid-cols-2 gap-2.5">
-                      {m.qa.trends.map((t) => (
-                        <MetricTrendRow key={t.label} s={t} />
-                      ))}
-                    </div>
+                    {m.qa.trends && (
+                      <div className="grid sm:grid-cols-2 gap-2.5">
+                        {m.qa.trends.map((t) => (
+                          <MetricTrendRow key={t.label} s={t} />
+                        ))}
+                      </div>
+                    )}
+                    {m.qa.events && (
+                      <ul className="space-y-1.5">
+                        {m.qa.events.map((e) => (
+                          <li
+                            key={e.label}
+                            className="flex items-center gap-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-2"
+                          >
+                            <span
+                              className="text-[10px] font-bold px-2 py-0.5 rounded-full text-white shrink-0 w-[88px] text-center"
+                              style={{
+                                background: EPA_TYPE_COLOR[e.type] ?? "#7D3C98",
+                              }}
+                            >
+                              {e.type}
+                            </span>
+                            <span className="text-xs font-mono text-[var(--text-secondary)] shrink-0">
+                              {e.date}
+                            </span>
+                            <span className="text-sm text-[var(--text-primary)]">
+                              {e.label}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                     <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
                       <ShieldCheck size={12} /> {m.qa.source}
                     </p>

--- a/ui/src/lib/personal-research.ts
+++ b/ui/src/lib/personal-research.ts
@@ -13,16 +13,31 @@ const fitness = personalHealth.find((s) => s.id === "fitness")!;
 const labs = personalHealth.find((s) => s.id === "labs")!;
 const nutrition = personalHealth.find((s) => s.id === "nutrition")!;
 
+/** A discrete clinical event from the patient's ePA (electronic patient record). */
+export interface EpaEvent {
+  date: string;
+  label: string;
+  type: "Infection" | "Surgery" | "Vaccination" | "Diagnosis";
+}
+
 export interface ResearchQA {
-  id: "sport" | "nutrition" | "breathing";
+  id:
+    | "sport"
+    | "nutrition"
+    | "breathing"
+    | "infections"
+    | "surgeries"
+    | "vaccines";
   question: string;
   answer: string;
   /** provenance line — always "own data only" */
   source: string;
-  /** trend series shown beneath the answer */
-  trends: TrendSeries[];
   /** keywords used to resolve a free-text question to this answer */
   keywords: string[];
+  /** trend series shown beneath the answer (metric questions) */
+  trends?: TrendSeries[];
+  /** discrete ePA events shown beneath the answer (record questions) */
+  events?: EpaEvent[];
 }
 
 export const personalResearchQA: ResearchQA[] = [
@@ -103,6 +118,115 @@ export const personalResearchQA: ResearchQA[] = [
       "anxiety",
       "hrv",
       "recovery",
+    ],
+  },
+  {
+    id: "infections",
+    question: "Which infections are recorded in my ePA?",
+    answer:
+      "Your ePA lists three infections over the past few years — seasonal influenza (2024), acute bronchitis (2023) and a mild COVID-19 episode (2022). All are marked resolved.",
+    source: "From your ePA (elektronische Patientenakte) — your own data only.",
+    keywords: [
+      "infection",
+      "infections",
+      "flu",
+      "influenza",
+      "covid",
+      "bronchitis",
+      "sick",
+      "illness",
+      "fever",
+      "virus",
+    ],
+    events: [
+      {
+        date: "2024-12-03",
+        label: "Influenza (seasonal) — resolved",
+        type: "Infection",
+      },
+      {
+        date: "2023-03-20",
+        label: "Acute bronchitis — resolved",
+        type: "Infection",
+      },
+      {
+        date: "2022-11-08",
+        label: "COVID-19, mild — recovered",
+        type: "Infection",
+      },
+    ],
+  },
+  {
+    id: "surgeries",
+    question: "What surgeries or operations have I had?",
+    answer:
+      "Your ePA shows two surgical procedures, both completed without recorded complications: a knee arthroscopy (2020) and a laparoscopic appendectomy (2018).",
+    source: "From your ePA (elektronische Patientenakte) — your own data only.",
+    keywords: [
+      "surgery",
+      "surgeries",
+      "operation",
+      "operations",
+      "operated",
+      "procedure",
+      "appendectomy",
+      "arthroscopy",
+      "knee",
+      "operative",
+    ],
+    events: [
+      {
+        date: "2020-09-22",
+        label: "Knee arthroscopy (meniscus repair)",
+        type: "Surgery",
+      },
+      {
+        date: "2018-06-14",
+        label: "Laparoscopic appendectomy",
+        type: "Surgery",
+      },
+    ],
+  },
+  {
+    id: "vaccines",
+    question: "Am I up to date on my vaccinations?",
+    answer:
+      "Mostly — your ePA shows seasonal influenza vaccines for 2024/25 and 2025/26 and a COVID-19 booster (2024). Your tetanus-diphtheria booster is from 2021, so the next one is due around 2031.",
+    source: "From your ePA (elektronische Patientenakte) — your own data only.",
+    keywords: [
+      "vaccine",
+      "vaccines",
+      "vaccination",
+      "vaccinations",
+      "immunization",
+      "immunisation",
+      "jab",
+      "shot",
+      "booster",
+      "flu shot",
+      "tetanus",
+    ],
+    events: [
+      {
+        date: "2025-10-15",
+        label: "Influenza vaccine 2025/26",
+        type: "Vaccination",
+      },
+      {
+        date: "2024-10-08",
+        label: "Influenza vaccine 2024/25",
+        type: "Vaccination",
+      },
+      {
+        date: "2024-04-02",
+        label: "COVID-19 mRNA booster",
+        type: "Vaccination",
+      },
+      {
+        date: "2021-05-18",
+        label: "Tetanus-diphtheria (Td) booster",
+        type: "Vaccination",
+      },
     ],
   },
 ];


### PR DESCRIPTION
Adds ePA record questions to /patient/query alongside the fitness/lab/nutrition trends: infections, surgeries/operations, vaccinations. Each resolves by keyword to an answer + a list of dated ePA events with a type badge, own data only. Maria's restricted record gains 9 ePA events (→ 38 timeline events) + a new Immunization timeline type.

Verified on :3000: vaccine/infection questions return event lists; timeline shows the new events. 1754 tests pass, coverage 82.22%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)