### PR TITLE
feat(patient): NLQ 3 questions w/ ePA events in answers + query-on-top + fast Pages deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Run Playwright E2E tests
         run: npx playwright test --project=chromium
         continue-on-error: true
+        # Informational only (continue-on-error) — cap it so it never delays the
+        # build+deploy that follow. The full suite runs in ci.yml on PRs.
+        timeout-minutes: 10
         env:
           CI: true
           NEXT_PUBLIC_STATIC_EXPORT: "false"
@@ -132,6 +135,7 @@ jobs:
       - name: WCAG 2.2 AA accessibility audit
         run: npx playwright test __tests__/e2e/journeys/27-wcag-accessibility.spec.ts --project=chromium
         continue-on-error: true
+        timeout-minutes: 6
         env:
           CI: true
           NEXT_PUBLIC_STATIC_EXPORT: "false"
@@ -141,6 +145,7 @@ jobs:
       - name: Security & penetration tests (OWASP/BSI)
         run: npx playwright test __tests__/e2e/journeys/28-security-pentest.spec.ts --project=chromium --grep-invert "SEC-4[1-9]|SEC-50"
         continue-on-error: true
+        timeout-minutes: 6
         env:
           CI: true
           NEXT_PUBLIC_STATIC_EXPORT: "false"

--- a/ui/__tests__/unit/pages/personal-query.test.tsx
+++ b/ui/__tests__/unit/pages/personal-query.test.tsx
@@ -13,9 +13,16 @@ afterEach(() => {
 });
 
 describe("Personal Research (NLQ) page", () => {
-  it("answers a typed free-text question only after Send, with a trend from own data", () => {
+  it("keeps exactly 3 questions", () => {
+    expect(personalResearchQA.map((q) => q.id)).toEqual([
+      "sport",
+      "nutrition",
+      "breathing",
+    ]);
+  });
+
+  it("answers a typed question after Send with a trend AND a related ePA event", () => {
     render(<PersonalQueryPage />);
-    // nothing shown before sending
     expect(screen.queryByText(/cardio-fitness improved/i)).toBeNull();
     const input = screen.getByLabelText(
       /Ask a question about your own health data/i,
@@ -26,16 +33,27 @@ describe("Personal Research (NLQ) page", () => {
     fireEvent.click(screen.getByLabelText(/Send question/i));
     expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
     expect(screen.getByText("VO₂max")).toBeInTheDocument();
-    expect(screen.getByText(/your own data only/i)).toBeInTheDocument();
+    // ePA event folded into the answer
+    expect(screen.getByText("Related ePA events")).toBeInTheDocument();
+    expect(screen.getByText(/meniscus repair/i)).toBeInTheDocument();
+    expect(screen.getByText("Surgery")).toBeInTheDocument();
   });
 
-  it("a suggestion chip sends the question and reveals the answer", () => {
+  it("a suggestion fills the box and submits, showing the answer below", () => {
     render(<PersonalQueryPage />);
-    fireEvent.click(screen.getByText(/increased my daily sport routine/i));
-    expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/breathing exercises/i));
+    const input = screen.getByLabelText(
+      /Ask a question about your own health data/i,
+    ) as HTMLInputElement;
+    // the question was copied into the box
+    expect(input.value).toMatch(/breathing exercises/i);
+    // breathing answer folds in respiratory ePA events
+    expect(screen.getByText(/CRP fell/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Infection").length).toBeGreaterThan(0);
+    expect(screen.getByText("Vaccination")).toBeInTheDocument();
   });
 
-  it("out-of-scope questions get a graceful own-data-only fallback", () => {
+  it("out-of-scope questions get a graceful own-data fallback", () => {
     render(<PersonalQueryPage />);
     const input = screen.getByLabelText(
       /Ask a question about your own health data/i,
@@ -47,50 +65,22 @@ describe("Personal Research (NLQ) page", () => {
     ).toBeInTheDocument();
   });
 
-  it("answers an ePA question (infections) with a list of events", () => {
-    render(<PersonalQueryPage />);
-    const input = screen.getByLabelText(
-      /Ask a question about your own health data/i,
-    );
-    fireEvent.change(input, {
-      target: { value: "which infections do I have?" },
-    });
-    fireEvent.click(screen.getByLabelText(/Send question/i));
-    expect(screen.getByText(/three infections/i)).toBeInTheDocument();
-    // "Acute bronchitis" appears in both the answer and the event row
-    expect(
-      screen.getAllByText(/Acute bronchitis/i).length,
-    ).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText("Infection").length).toBe(3);
-    expect(
-      screen.getByText(/elektronische Patientenakte/i),
-    ).toBeInTheDocument();
-  });
-
-  it("matchPersonalResearch maps keywords to the right answer (or null)", () => {
+  it("matchPersonalResearch maps keywords to one of the 3 answers (or null)", () => {
     expect(matchPersonalResearch("my running and VO2")?.id).toBe("sport");
-    expect(matchPersonalResearch("breathing and stress")?.id).toBe("breathing");
     expect(matchPersonalResearch("nutrition and cholesterol")?.id).toBe(
       "nutrition",
     );
-    expect(matchPersonalResearch("which infections have I had")?.id).toBe(
-      "infections",
+    expect(matchPersonalResearch("breathing, asthma and covid")?.id).toBe(
+      "breathing",
     );
-    expect(matchPersonalResearch("any surgeries or operations")?.id).toBe(
-      "surgeries",
-    );
-    expect(
-      matchPersonalResearch("am I up to date on my vaccinations")?.id,
-    ).toBe("vaccines");
     expect(matchPersonalResearch("hello world")).toBeNull();
   });
 
-  it("every Q&A is computed from the patient's own data only", () => {
+  it("every Q&A draws on own data — trends + ePA events", () => {
     for (const qa of personalResearchQA) {
       expect(qa.source).toMatch(/own data only/i);
-      expect(
-        (qa.trends?.length ?? 0) + (qa.events?.length ?? 0),
-      ).toBeGreaterThan(0);
+      expect(qa.trends.length).toBeGreaterThan(0);
+      expect(qa.events.length).toBeGreaterThan(0);
       expect(qa.keywords.length).toBeGreaterThan(0);
     }
   });

--- a/ui/src/app/patient/query/page.tsx
+++ b/ui/src/app/patient/query/page.tsx
@@ -2,11 +2,11 @@
 
 /**
  * Personal Research — a natural-language-query page over the patient's OWN data
- * (EHDS Art. 3 / GDPR Art. 15 primary use). Type a question (or tap a
- * suggestion) and Send; the answer + trend graphs — computed only from the
- * patient's own fitness / lab / nutrition records — appear in the conversation.
- * No LLM in the static demo: free text is keyword-matched to a predefined
- * answer. Synthetic · illustrative.
+ * (EHDS Art. 3 / GDPR Art. 15 primary use). The query box is at the top; type a
+ * question (or tap a suggestion, which fills the box and submits) and the answer
+ * — fitness/lab/nutrition trends PLUS relevant ePA events (infections, surgery,
+ * vaccinations, diagnoses) — appears below, computed only from the patient's own
+ * records. No LLM in the static demo: free text is keyword-matched. Synthetic.
  */
 import { useState } from "react";
 import {
@@ -14,9 +14,6 @@ import {
   Activity,
   Salad,
   Wind,
-  Bug,
-  Scissors,
-  Syringe,
   ShieldCheck,
   Send,
   Info,
@@ -34,9 +31,6 @@ const QA_ICON: Record<string, LucideIcon> = {
   sport: Activity,
   nutrition: Salad,
   breathing: Wind,
-  infections: Bug,
-  surgeries: Scissors,
-  vaccines: Syringe,
 };
 
 /** Badge colour per ePA event type. */
@@ -47,33 +41,24 @@ const EPA_TYPE_COLOR: Record<string, string> = {
   Diagnosis: "#7D3C98",
 };
 
-interface Message {
-  role: "user" | "assistant";
-  text: string;
-  qa?: ResearchQA;
-  fallback?: boolean;
+interface Exchange {
+  question: string;
+  qa: ResearchQA | null;
 }
 
 export default function PersonalQueryPage() {
   const [input, setInput] = useState("");
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [exchanges, setExchanges] = useState<Exchange[]>([]);
 
   function send(text: string) {
     const q = text.trim();
     if (!q) return;
-    const qa = matchPersonalResearch(q);
-    setMessages((m) => [
-      ...m,
-      { role: "user", text: q },
-      qa
-        ? { role: "assistant", text: qa.answer, qa }
-        : {
-            role: "assistant",
-            fallback: true,
-            text: "I can only answer from your own fitness, lab and nutrition records. Try asking about your sport routine, your nutrition, or your breathing exercises.",
-          },
+    setInput(q); // keep the query visible in the box
+    // newest first — the latest answer shows directly under the field
+    setExchanges((prev) => [
+      { question: q, qa: matchPersonalResearch(q) },
+      ...prev,
     ]);
-    setInput("");
   }
 
   return (
@@ -82,119 +67,13 @@ export default function PersonalQueryPage() {
         <PageIntro
           title="Personal Research"
           icon={Sparkles}
-          description="Ask a question about your own health data — fitness, lab and nutrition trends, or your ePA record (infections, surgeries, vaccinations and more). Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
+          description="Ask a question about your own health data — fitness, lab and nutrition trends together with your ePA record (infections, surgeries, vaccinations and diagnoses). Answers are computed only from your own records (EHDS Art. 3 / GDPR Art. 15 — primary use). Synthetic · illustrative — not medical advice."
           prevStep={{ href: "/patient", label: "My Health Records" }}
           nextStep={{ href: "/patient/insights", label: "Research Insights" }}
           infoText="This is primary use: you query your own data. It never leaves your record and is not compared against other patients. The static demo matches your free-text question to a predefined answer by keyword (no AI model)."
         />
 
-        {/* Conversation */}
-        <div className="space-y-4 mb-5 min-h-[80px]">
-          {messages.length === 0 && (
-            <div className="text-center text-sm text-[var(--text-secondary)] py-8 rounded-xl border border-dashed border-[var(--border)]">
-              Type a question below — or tap a suggestion — to see an answer
-              from your own data.
-            </div>
-          )}
-          {messages.map((m, i) =>
-            m.role === "user" ? (
-              <div key={i} className="flex justify-end">
-                <p className="max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--accent)] text-white px-4 py-2.5 text-sm">
-                  {m.text}
-                </p>
-              </div>
-            ) : (
-              <div
-                key={i}
-                className="rounded-2xl rounded-bl-sm border border-[var(--border)] bg-[var(--surface)] p-4"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span
-                    className="grid place-items-center w-8 h-8 rounded-lg text-white shrink-0"
-                    style={{ background: m.fallback ? "#64748b" : "#7D3C98" }}
-                  >
-                    {(() => {
-                      const Icon = m.qa ? QA_ICON[m.qa.id] ?? Sparkles : Info;
-                      return <Icon size={16} />;
-                    })()}
-                  </span>
-                  <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Your data assistant
-                  </span>
-                </div>
-                <p className="text-sm text-[var(--text-primary)] leading-relaxed mb-3">
-                  {m.text}
-                </p>
-                {m.qa && (
-                  <>
-                    {m.qa.trends && (
-                      <div className="grid sm:grid-cols-2 gap-2.5">
-                        {m.qa.trends.map((t) => (
-                          <MetricTrendRow key={t.label} s={t} />
-                        ))}
-                      </div>
-                    )}
-                    {m.qa.events && (
-                      <ul className="space-y-1.5">
-                        {m.qa.events.map((e) => (
-                          <li
-                            key={e.label}
-                            className="flex items-center gap-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-2"
-                          >
-                            <span
-                              className="text-[10px] font-bold px-2 py-0.5 rounded-full text-white shrink-0 w-[88px] text-center"
-                              style={{
-                                background: EPA_TYPE_COLOR[e.type] ?? "#7D3C98",
-                              }}
-                            >
-                              {e.type}
-                            </span>
-                            <span className="text-xs font-mono text-[var(--text-secondary)] shrink-0">
-                              {e.date}
-                            </span>
-                            <span className="text-sm text-[var(--text-primary)]">
-                              {e.label}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                    <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
-                      <ShieldCheck size={12} /> {m.qa.source}
-                    </p>
-                  </>
-                )}
-              </div>
-            ),
-          )}
-        </div>
-
-        {/* Suggestions */}
-        <p className="section-label mb-2">Suggested questions</p>
-        <div className="flex flex-col gap-2 mb-4">
-          {personalResearchQA.map((qa) => {
-            const Icon = QA_ICON[qa.id] ?? Sparkles;
-            return (
-              <button
-                key={qa.id}
-                type="button"
-                onClick={() => send(qa.question)}
-                className="flex items-center gap-3 text-left rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3 hover:border-[var(--accent)] transition-colors"
-              >
-                <Icon
-                  size={16}
-                  className="shrink-0 text-[var(--accent)]"
-                  aria-hidden="true"
-                />
-                <span className="text-sm text-[var(--text-primary)]">
-                  {qa.question}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Free-text input */}
+        {/* Query box — at the top */}
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -220,9 +99,118 @@ export default function PersonalQueryPage() {
             <Send size={18} />
           </button>
         </form>
+
+        {/* Suggestions — click fills the box and submits */}
+        <div className="flex flex-wrap gap-2 mt-3">
+          {personalResearchQA.map((qa) => {
+            const Icon = QA_ICON[qa.id] ?? Sparkles;
+            return (
+              <button
+                key={qa.id}
+                type="button"
+                onClick={() => send(qa.question)}
+                className="inline-flex items-center gap-2 text-left rounded-full border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1.5 text-xs text-[var(--text-primary)] hover:border-[var(--accent)] transition-colors"
+              >
+                <Icon
+                  size={13}
+                  className="shrink-0 text-[var(--accent)]"
+                  aria-hidden="true"
+                />
+                {qa.question}
+              </button>
+            );
+          })}
+        </div>
         <p className="text-[11px] text-[var(--text-secondary)] mt-2">
           Your own records only · synthetic · not medical advice
         </p>
+
+        {/* Answers — below the field, newest first */}
+        <div className="space-y-4 mt-6">
+          {exchanges.length === 0 && (
+            <div className="text-center text-sm text-[var(--text-secondary)] py-8 rounded-xl border border-dashed border-[var(--border)]">
+              Ask a question above — or tap a suggestion — to see an answer from
+              your own data.
+            </div>
+          )}
+          {exchanges.map((x, i) => {
+            const Icon = x.qa ? QA_ICON[x.qa.id] ?? Sparkles : Info;
+            return (
+              <div key={exchanges.length - i} className="space-y-2">
+                {/* question */}
+                <div className="flex justify-end">
+                  <p className="max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--accent)] text-white px-4 py-2.5 text-sm">
+                    {x.question}
+                  </p>
+                </div>
+                {/* answer */}
+                <div className="rounded-2xl rounded-bl-sm border border-[var(--border)] bg-[var(--surface)] p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span
+                      className="grid place-items-center w-8 h-8 rounded-lg text-white shrink-0"
+                      style={{ background: x.qa ? "#7D3C98" : "#64748b" }}
+                    >
+                      <Icon size={16} />
+                    </span>
+                    <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Your data assistant
+                    </span>
+                  </div>
+                  {x.qa ? (
+                    <>
+                      <p className="text-sm text-[var(--text-primary)] leading-relaxed mb-3">
+                        {x.qa.answer}
+                      </p>
+                      <div className="grid sm:grid-cols-2 gap-2.5">
+                        {x.qa.trends.map((t) => (
+                          <MetricTrendRow key={t.label} s={t} />
+                        ))}
+                      </div>
+                      {x.qa.events.length > 0 && (
+                        <ul className="space-y-1.5 mt-2.5">
+                          <li className="text-[10px] font-bold uppercase tracking-wide text-[var(--text-secondary)]">
+                            Related ePA events
+                          </li>
+                          {x.qa.events.map((e) => (
+                            <li
+                              key={e.label}
+                              className="flex items-center gap-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-2"
+                            >
+                              <span
+                                className="text-[10px] font-bold px-2 py-0.5 rounded-full text-white shrink-0 w-[88px] text-center"
+                                style={{
+                                  background:
+                                    EPA_TYPE_COLOR[e.type] ?? "#7D3C98",
+                                }}
+                              >
+                                {e.type}
+                              </span>
+                              <span className="text-xs font-mono text-[var(--text-secondary)] shrink-0">
+                                {e.date}
+                              </span>
+                              <span className="text-sm text-[var(--text-primary)]">
+                                {e.label}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] mt-3">
+                        <ShieldCheck size={12} /> {x.qa.source}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="text-sm text-[var(--text-primary)] leading-relaxed">
+                      I can only answer from your own fitness, lab, nutrition
+                      and ePA records. Try asking about your sport routine, your
+                      nutrition, or your breathing &amp; respiratory history.
+                    </p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/ui/src/lib/personal-research.ts
+++ b/ui/src/lib/personal-research.ts
@@ -1,11 +1,12 @@
 /**
  * Predefined personal-research questions for the patient's own data (NLQ page).
- * Each question maps to trend series from `personalHealth` (the patient's own
- * fitness / lab / nutrition data) — EHDS Art. 3 / GDPR Art. 15 primary use, own
- * records only. Synthetic · illustrative.
+ * Three questions, each answered from the patient's own data — fitness / lab /
+ * nutrition trends PLUS relevant ePA (elektronische Patientenakte) events
+ * (infections, surgery, vaccinations, diagnoses). EHDS Art. 3 / GDPR Art. 15
+ * primary use, own records only. Synthetic · illustrative.
  *
- * The NLQ page accepts free-text questions; `matchPersonalResearch` resolves a
- * typed question to one of these answers by keyword (no LLM in the static demo).
+ * Free-text questions are resolved to one of these by keyword (no LLM in the
+ * static demo).
  */
 import { personalHealth, type TrendSeries } from "@/lib/journey-config";
 
@@ -21,23 +22,17 @@ export interface EpaEvent {
 }
 
 export interface ResearchQA {
-  id:
-    | "sport"
-    | "nutrition"
-    | "breathing"
-    | "infections"
-    | "surgeries"
-    | "vaccines";
+  id: "sport" | "nutrition" | "breathing";
   question: string;
   answer: string;
   /** provenance line — always "own data only" */
   source: string;
   /** keywords used to resolve a free-text question to this answer */
   keywords: string[];
-  /** trend series shown beneath the answer (metric questions) */
-  trends?: TrendSeries[];
-  /** discrete ePA events shown beneath the answer (record questions) */
-  events?: EpaEvent[];
+  /** trend series shown beneath the answer */
+  trends: TrendSeries[];
+  /** relevant ePA events shown beneath the answer */
+  events: EpaEvent[];
 }
 
 export const personalResearchQA: ResearchQA[] = [
@@ -46,9 +41,9 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I increased my daily sport routine over the last 3 months — do you see any effect?",
     answer:
-      "Yes — your cardio-fitness improved. VO₂max rose from 42 to 47 ml/kg/min and your heart-rate variability climbed, both signs of better recovery and a lower resting heart rate.",
-    source: "Computed from your fitness band — your own data only.",
-    trends: [fitness.trends[0], fitness.trends[1]],
+      "Yes — your cardio-fitness improved: VO₂max rose from 42 to 47 ml/kg/min and your heart-rate variability climbed. Your ePA confirms you fully recovered from your 2020 knee arthroscopy and trained through the period without setbacks — you're fitter than before.",
+    source:
+      "From your fitness band + ePA (elektronische Patientenakte) — your own data only.",
     keywords: [
       "sport",
       "exercise",
@@ -65,6 +60,15 @@ export const personalResearchQA: ResearchQA[] = [
       "gym",
       "active",
       "steps",
+      "knee",
+    ],
+    trends: [fitness.trends[0], fitness.trends[1]],
+    events: [
+      {
+        date: "2020-09-22",
+        label: "Knee arthroscopy (meniscus repair)",
+        type: "Surgery",
+      },
     ],
   },
   {
@@ -72,10 +76,8 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I changed my nutrition over 3 months — how are my cardiovascular and pre-diabetes markers?",
     answer:
-      "Trending the right way — inflammation (CRP) is down and vitamin D is up, both consistent with lower cardiovascular risk. Your Mediterranean-plan adherence reached 86%.",
-    source:
-      "Computed from your lab panel and nutrition plan — your own data only.",
-    trends: [labs.trends[2], nutrition.trends[0]],
+      "Trending the right way — inflammation (CRP) is down and your Mediterranean-plan adherence reached 86%. That directly helps the conditions on your ePA: your pre-diabetes (2023) and mixed hyperlipidaemia (2024), now managed alongside atorvastatin.",
+    source: "From your lab panel, nutrition plan + ePA — your own data only.",
     keywords: [
       "nutrition",
       "diet",
@@ -90,9 +92,23 @@ export const personalResearchQA: ResearchQA[] = [
       "prediabetes",
       "cholesterol",
       "ldl",
+      "hyperlipidaemia",
       "weight",
       "mediterranean",
       "vitamin d",
+    ],
+    trends: [labs.trends[2], nutrition.trends[0]],
+    events: [
+      {
+        date: "2023-10-02",
+        label: "Pre-diabetes (impaired fasting glucose)",
+        type: "Diagnosis",
+      },
+      {
+        date: "2024-03-15",
+        label: "Mixed hyperlipidaemia",
+        type: "Diagnosis",
+      },
     ],
   },
   {
@@ -100,10 +116,8 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I've been doing daily breathing exercises — any effect on stress and inflammation?",
     answer:
-      "Likely yes — your inflammation marker (CRP) fell from 2.1 to 0.8 mg/L this quarter and your HRV improved. Lower CRP and higher HRV both point to a reduced stress load.",
-    source:
-      "Computed from your lab panel and fitness band — your own data only.",
-    trends: [labs.trends[2], fitness.trends[1]],
+      "Likely yes — CRP fell from 2.1 to 0.8 mg/L and your HRV improved. Set against your ePA respiratory history — mild asthma, plus a resolved bronchitis (2023) and COVID-19 (2022) — your inflammation is now low, and your seasonal influenza vaccinations are up to date.",
+    source: "From your lab panel, fitness band + ePA — your own data only.",
     keywords: [
       "breath",
       "breathing",
@@ -118,26 +132,18 @@ export const personalResearchQA: ResearchQA[] = [
       "anxiety",
       "hrv",
       "recovery",
-    ],
-  },
-  {
-    id: "infections",
-    question: "Which infections are recorded in my ePA?",
-    answer:
-      "Your ePA lists three infections over the past few years — seasonal influenza (2024), acute bronchitis (2023) and a mild COVID-19 episode (2022). All are marked resolved.",
-    source: "From your ePA (elektronische Patientenakte) — your own data only.",
-    keywords: [
+      "asthma",
+      "respiratory",
       "infection",
       "infections",
-      "flu",
-      "influenza",
       "covid",
+      "flu",
       "bronchitis",
-      "sick",
-      "illness",
-      "fever",
-      "virus",
+      "vaccine",
+      "vaccination",
+      "immunization",
     ],
+    trends: [labs.trends[2], fitness.trends[1]],
     events: [
       {
         date: "2024-12-03",
@@ -145,87 +151,19 @@ export const personalResearchQA: ResearchQA[] = [
         type: "Infection",
       },
       {
-        date: "2023-03-20",
-        label: "Acute bronchitis — resolved",
-        type: "Infection",
-      },
-      {
         date: "2022-11-08",
         label: "COVID-19, mild — recovered",
         type: "Infection",
       },
-    ],
-  },
-  {
-    id: "surgeries",
-    question: "What surgeries or operations have I had?",
-    answer:
-      "Your ePA shows two surgical procedures, both completed without recorded complications: a knee arthroscopy (2020) and a laparoscopic appendectomy (2018).",
-    source: "From your ePA (elektronische Patientenakte) — your own data only.",
-    keywords: [
-      "surgery",
-      "surgeries",
-      "operation",
-      "operations",
-      "operated",
-      "procedure",
-      "appendectomy",
-      "arthroscopy",
-      "knee",
-      "operative",
-    ],
-    events: [
-      {
-        date: "2020-09-22",
-        label: "Knee arthroscopy (meniscus repair)",
-        type: "Surgery",
-      },
-      {
-        date: "2018-06-14",
-        label: "Laparoscopic appendectomy",
-        type: "Surgery",
-      },
-    ],
-  },
-  {
-    id: "vaccines",
-    question: "Am I up to date on my vaccinations?",
-    answer:
-      "Mostly — your ePA shows seasonal influenza vaccines for 2024/25 and 2025/26 and a COVID-19 booster (2024). Your tetanus-diphtheria booster is from 2021, so the next one is due around 2031.",
-    source: "From your ePA (elektronische Patientenakte) — your own data only.",
-    keywords: [
-      "vaccine",
-      "vaccines",
-      "vaccination",
-      "vaccinations",
-      "immunization",
-      "immunisation",
-      "jab",
-      "shot",
-      "booster",
-      "flu shot",
-      "tetanus",
-    ],
-    events: [
       {
         date: "2025-10-15",
         label: "Influenza vaccine 2025/26",
         type: "Vaccination",
       },
       {
-        date: "2024-10-08",
-        label: "Influenza vaccine 2024/25",
-        type: "Vaccination",
-      },
-      {
-        date: "2024-04-02",
-        label: "COVID-19 mRNA booster",
-        type: "Vaccination",
-      },
-      {
-        date: "2021-05-18",
-        label: "Tetanus-diphtheria (Td) booster",
-        type: "Vaccination",
+        date: "2021-09-09",
+        label: "Mild intermittent asthma",
+        type: "Diagnosis",
       },
     ],
   },
@@ -234,7 +172,7 @@ export const personalResearchQA: ResearchQA[] = [
 /**
  * Resolve a free-text question to one of the predefined answers by keyword
  * overlap (the static demo has no LLM). Returns the best match, or null when the
- * question is outside the patient's own fitness / lab / nutrition data.
+ * question is outside the patient's own data.
  */
 export function matchPersonalResearch(text: string): ResearchQA | null {
   const t = text.toLowerCase();


### PR DESCRIPTION
Per feedback: keep the **3 questions**; fold the **ePA events** (infections, surgery, vaccinations, diagnoses) into each answer as a 'Related ePA events' list under the trend charts. Layout reworked — **query box on top**; tapping a suggestion **fills the box, submits, and the answer appears below** (newest first).

Also includes the **pages.yml fast-deploy fix** (caps the non-blocking E2E/WCAG/security steps with timeout-minutes) so this — and future — Pages deploys finish in minutes instead of ~1 h. This is why the NLQ never went live before: each ~55-min deploy was cancelled by the next supersession.

1754 tests pass, coverage 82.22%. Verified on :3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)