### PR TITLE
feat(patient): mark ePA events on the answer trend graphs

### DIFF
--- a/ui/__tests__/unit/pages/eudi-qr.test.tsx
+++ b/ui/__tests__/unit/pages/eudi-qr.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import EudiQrPage from "@/app/auth/eudi-qr/page";
 import { signIn } from "next-auth/react";
 
@@ -54,7 +54,8 @@ describe("EudiQrPage", () => {
   });
 
   it("signs in when the wallet completes the presentation", async () => {
-    vi.useFakeTimers();
+    // Real timers + waitFor (not fake timers): the async start() resolves on the
+    // microtask queue, which fake-timer advancement raced — making this flaky.
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) =>
@@ -75,10 +76,15 @@ describe("EudiQrPage", () => {
       ),
     );
     render(<EudiQrPage />);
-    // flush start() → phase "scanning" → poll effect registers
-    await vi.advanceTimersByTimeAsync(0);
-    // fire the 2s poll → status completed → signIn
-    await vi.advanceTimersByTimeAsync(2100);
+    // start() → scanning → poll (every 2s) → status completed → signIn
+    await waitFor(
+      () =>
+        expect(signIn).toHaveBeenCalledWith(
+          "eudi-wallet",
+          expect.objectContaining({ sid: "s2" }),
+        ),
+      { timeout: 6000 },
+    );
     expect(signIn).toHaveBeenCalledWith(
       "eudi-wallet",
       expect.objectContaining({ sid: "s2" }),

--- a/ui/__tests__/unit/pages/personal-query.test.tsx
+++ b/ui/__tests__/unit/pages/personal-query.test.tsx
@@ -34,7 +34,7 @@ describe("Personal Research (NLQ) page", () => {
     expect(screen.getByText(/cardio-fitness improved/i)).toBeInTheDocument();
     expect(screen.getByText("VO₂max")).toBeInTheDocument();
     // ePA event folded into the answer
-    expect(screen.getByText("Related ePA events")).toBeInTheDocument();
+    expect(screen.getByText(/Related ePA events/)).toBeInTheDocument();
     expect(screen.getByText(/meniscus repair/i)).toBeInTheDocument();
     expect(screen.getByText("Surgery")).toBeInTheDocument();
   });

--- a/ui/src/app/patient/query/page.tsx
+++ b/ui/src/app/patient/query/page.tsx
@@ -24,6 +24,7 @@ import { MetricTrendRow } from "@/components/charts/MetricTrendRow";
 import {
   personalResearchQA,
   matchPersonalResearch,
+  eventMarkers,
   type ResearchQA,
 } from "@/lib/personal-research";
 
@@ -163,13 +164,21 @@ export default function PersonalQueryPage() {
                       </p>
                       <div className="grid sm:grid-cols-2 gap-2.5">
                         {x.qa.trends.map((t) => (
-                          <MetricTrendRow key={t.label} s={t} />
+                          <MetricTrendRow
+                            key={t.label}
+                            s={t}
+                            markers={eventMarkers(
+                              t,
+                              x.qa!.events,
+                              (type) => EPA_TYPE_COLOR[type] ?? "#7D3C98",
+                            )}
+                          />
                         ))}
                       </div>
                       {x.qa.events.length > 0 && (
                         <ul className="space-y-1.5 mt-2.5">
                           <li className="text-[10px] font-bold uppercase tracking-wide text-[var(--text-secondary)]">
-                            Related ePA events
+                            Related ePA events · marked on the trends
                           </li>
                           {x.qa.events.map((e) => (
                             <li

--- a/ui/src/components/charts/MetricTrendRow.tsx
+++ b/ui/src/components/charts/MetricTrendRow.tsx
@@ -2,14 +2,20 @@
 
 /**
  * MetricTrendRow — a labelled trend series (value + unit + improving/declining
- * chip + TrendChart). Reused by the personal-research NLQ answers. Pure
- * presentational; synthetic data.
+ * chip + TrendChart). Optional `markers` annotate ePA events on the line, and a
+ * multi-year series shows its date range. Pure presentational; synthetic data.
  */
 import { TrendingUp, TrendingDown } from "lucide-react";
-import { TrendChart } from "@/components/charts/TrendChart";
+import { TrendChart, type TrendMarker } from "@/components/charts/TrendChart";
 import type { TrendSeries } from "@/lib/journey-config";
 
-export function MetricTrendRow({ s }: { s: TrendSeries }) {
+export function MetricTrendRow({
+  s,
+  markers = [],
+}: {
+  s: TrendSeries;
+  markers?: TrendMarker[];
+}) {
   const first = s.points[0];
   const last = s.points[s.points.length - 1];
   const rising = last >= first;
@@ -18,6 +24,13 @@ export function MetricTrendRow({ s }: { s: TrendSeries }) {
     first === 0 ? 0 : Math.round(((last - first) / Math.abs(first)) * 100);
   const Icon = rising ? TrendingUp : TrendingDown;
   const colour = improving ? "#1E8449" : "#CA6F1E";
+
+  // Span label: multi-year series show their year span; otherwise "3 mo".
+  const fromYear = s.from?.slice(0, 4);
+  const toYear = s.to?.slice(0, 4);
+  const years = fromYear && toYear ? Number(toYear) - Number(fromYear) : 0;
+  const span = years >= 1 ? `${years}y` : "3 mo";
+
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3">
       <div className="flex items-baseline justify-between gap-2 mb-1.5">
@@ -36,10 +49,21 @@ export function MetricTrendRow({ s }: { s: TrendSeries }) {
         >
           <Icon size={12} />
           {pct > 0 ? "+" : ""}
-          {pct}% · 3 mo
+          {pct}% · {span}
         </span>
       </div>
-      <TrendChart points={s.points} color={s.color} height={48} />
+      <TrendChart
+        points={s.points}
+        color={s.color}
+        height={56}
+        markers={markers}
+      />
+      {fromYear && toYear && (
+        <div className="flex justify-between text-[10px] text-[var(--text-secondary)] mt-1 tabular-nums">
+          <span>{fromYear}</span>
+          <span>{toYear}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/charts/TrendChart.tsx
+++ b/ui/src/components/charts/TrendChart.tsx
@@ -3,16 +3,26 @@
 /**
  * TrendChart — a tiny zero-dependency SVG line+area sparkline for personal-health
  * trends (normalised to the series min/max so small variations are visible).
- * Pure presentational; synthetic data. Reused by the /patient detail views.
+ * Optional `markers` overlay vertical event annotations (rendered as HTML so
+ * they aren't distorted by the stretched SVG). Pure presentational; synthetic.
  */
+export interface TrendMarker {
+  /** position along the x-axis, 0 (oldest) … 1 (newest) */
+  x: number;
+  color: string;
+  label: string;
+}
+
 export function TrendChart({
   points,
   color,
   height = 64,
+  markers = [],
 }: {
   points: number[];
   color: string;
   height?: number;
+  markers?: TrendMarker[];
 }) {
   if (!points || points.length < 2) return null;
   const W = 260;
@@ -30,30 +40,51 @@ export function TrendChart({
   const area = `${pad},${H - pad} ${line} ${W - pad},${H - pad}`;
   const gid = `tg-${color.replace("#", "")}`;
   return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      preserveAspectRatio="none"
-      role="img"
-      aria-hidden="true"
-      className="block w-full"
-      style={{ height }}
-    >
-      <defs>
-        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={color} stopOpacity="0.28" />
-          <stop offset="100%" stopColor={color} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <polygon points={area} fill={`url(#${gid})`} />
-      <polyline
-        points={line}
-        fill="none"
-        stroke={color}
-        strokeWidth="2"
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        vectorEffect="non-scaling-stroke"
-      />
-    </svg>
+    <div className="relative w-full" style={{ height }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-hidden="true"
+        className="block w-full h-full"
+      >
+        <defs>
+          <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.28" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <polygon points={area} fill={`url(#${gid})`} />
+        <polyline
+          points={line}
+          fill="none"
+          stroke={color}
+          strokeWidth="2"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      {markers.map((m, i) => {
+        const left = `${Math.max(0, Math.min(1, m.x)) * 100}%`;
+        return (
+          <div
+            key={i}
+            className="absolute top-0 bottom-0 pointer-events-none"
+            style={{ left }}
+            title={m.label}
+          >
+            <div
+              className="absolute top-1.5 bottom-1.5 -translate-x-1/2 border-l border-dashed"
+              style={{ borderColor: m.color, opacity: 0.75 }}
+            />
+            <div
+              className="absolute top-0 -translate-x-1/2 w-2 h-2 rounded-full ring-1 ring-white"
+              style={{ background: m.color }}
+            />
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/ui/src/lib/journey-config.ts
+++ b/ui/src/lib/journey-config.ts
@@ -92,16 +92,20 @@ export interface HealthMetric {
   value: string;
 }
 
-/** A ~3-month weekly trend series shown in the detail view. */
+/** A trend series shown in the detail view (3-month dashboards or multi-year NLQ). */
 export interface TrendSeries {
   label: string;
   unit: string;
   color: string;
   current: string;
-  /** oldest → newest, ~12 weekly points */
+  /** oldest → newest, evenly spaced from `from` to `to` */
   points: number[];
   /** which direction is the healthy one (for the ▲/▼ chip) */
   goodDirection: "up" | "down";
+  /** optional ISO date of points[0] — when set, ePA event markers can be placed */
+  from?: string;
+  /** optional ISO date of the last point */
+  to?: string;
 }
 
 /** A day in the nutrition weekly plan. */

--- a/ui/src/lib/personal-research.ts
+++ b/ui/src/lib/personal-research.ts
@@ -1,18 +1,12 @@
 /**
  * Predefined personal-research questions for the patient's own data (NLQ page).
- * Three questions, each answered from the patient's own data — fitness / lab /
- * nutrition trends PLUS relevant ePA (elektronische Patientenakte) events
- * (infections, surgery, vaccinations, diagnoses). EHDS Art. 3 / GDPR Art. 15
- * primary use, own records only. Synthetic · illustrative.
- *
- * Free-text questions are resolved to one of these by keyword (no LLM in the
- * static demo).
+ * Three questions, each answered from the patient's own data — multi-year
+ * fitness / lab / nutrition trends PLUS the ePA (elektronische Patientenakte)
+ * events that shaped them (infections spike CRP, the knee surgery dips VO₂max,
+ * etc.). The events are also marked on the trend charts. EHDS Art. 3 / GDPR
+ * Art. 15 primary use, own records only. Synthetic · illustrative.
  */
-import { personalHealth, type TrendSeries } from "@/lib/journey-config";
-
-const fitness = personalHealth.find((s) => s.id === "fitness")!;
-const labs = personalHealth.find((s) => s.id === "labs")!;
-const nutrition = personalHealth.find((s) => s.id === "nutrition")!;
+import type { TrendSeries } from "@/lib/journey-config";
 
 /** A discrete clinical event from the patient's ePA (electronic patient record). */
 export interface EpaEvent {
@@ -29,11 +23,53 @@ export interface ResearchQA {
   source: string;
   /** keywords used to resolve a free-text question to this answer */
   keywords: string[];
-  /** trend series shown beneath the answer */
+  /** multi-year trend series (events from `events` are marked on them) */
   trends: TrendSeries[];
-  /** relevant ePA events shown beneath the answer */
+  /** ePA events shown beneath, and marked on, the trends */
   events: EpaEvent[];
 }
+
+/** Fraction (0–1) of `date` within [from, to]. */
+function frac(from: string, to: string, date: string): number {
+  const f = Date.parse(from);
+  const t = Date.parse(to);
+  return (Date.parse(date) - f) / (t - f);
+}
+
+/**
+ * Generate `n` evenly-spaced points from `start` → `end`, adding a transient
+ * bump near each event date (positive = spike, negative = dip), so the curve
+ * reflects the ePA events.
+ */
+function gen(
+  from: string,
+  to: string,
+  start: number,
+  end: number,
+  n: number,
+  bumps: { date: string; mag: number }[] = [],
+  decimals = 0,
+): number[] {
+  const f = Math.pow(10, decimals);
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const x = i / (n - 1);
+    let v = start + (end - start) * x;
+    for (const b of bumps) {
+      const dist = Math.abs(x - frac(from, to, b.date)) * (n - 1);
+      v += b.mag * Math.max(0, 1 - dist / 1.5);
+    }
+    out.push(Math.round(Math.max(0, v) * f) / f);
+  }
+  return out;
+}
+
+const SPORT_FROM = "2020-06-01";
+const SPORT_TO = "2026-03-01";
+const NUTR_FROM = "2023-06-01";
+const NUTR_TO = "2026-03-01";
+const BREATH_FROM = "2021-06-01";
+const BREATH_TO = "2026-03-01";
 
 export const personalResearchQA: ResearchQA[] = [
   {
@@ -41,7 +77,7 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I increased my daily sport routine over the last 3 months — do you see any effect?",
     answer:
-      "Yes — your cardio-fitness improved: VO₂max rose from 42 to 47 ml/kg/min and your heart-rate variability climbed. Your ePA confirms you fully recovered from your 2020 knee arthroscopy and trained through the period without setbacks — you're fitter than before.",
+      "Yes — your cardio-fitness improved: VO₂max recovered after your 2020 knee arthroscopy and has climbed to 47 ml/kg/min, with heart-rate variability up too. The dip on the graph marks the surgery; you're now fitter than before it.",
     source:
       "From your fitness band + ePA (elektronische Patientenakte) — your own data only.",
     keywords: [
@@ -62,7 +98,32 @@ export const personalResearchQA: ResearchQA[] = [
       "steps",
       "knee",
     ],
-    trends: [fitness.trends[0], fitness.trends[1]],
+    trends: [
+      {
+        label: "VO₂max",
+        unit: "ml/kg/min",
+        color: "#CA6F1E",
+        current: "47",
+        goodDirection: "up",
+        from: SPORT_FROM,
+        to: SPORT_TO,
+        points: gen(SPORT_FROM, SPORT_TO, 43, 47, 18, [
+          { date: "2020-09-22", mag: -6 },
+        ]),
+      },
+      {
+        label: "HRV",
+        unit: "ms",
+        color: "#2471A3",
+        current: "48",
+        goodDirection: "up",
+        from: SPORT_FROM,
+        to: SPORT_TO,
+        points: gen(SPORT_FROM, SPORT_TO, 40, 48, 18, [
+          { date: "2020-09-22", mag: -7 },
+        ]),
+      },
+    ],
     events: [
       {
         date: "2020-09-22",
@@ -76,7 +137,7 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I changed my nutrition over 3 months — how are my cardiovascular and pre-diabetes markers?",
     answer:
-      "Trending the right way — inflammation (CRP) is down and your Mediterranean-plan adherence reached 86%. That directly helps the conditions on your ePA: your pre-diabetes (2023) and mixed hyperlipidaemia (2024), now managed alongside atorvastatin.",
+      "Trending the right way — inflammation (CRP) is down and your Mediterranean-plan adherence reached 86%. The markers show when your pre-diabetes (2023) and mixed hyperlipidaemia (2024) were diagnosed; both are improving since you changed your nutrition.",
     source: "From your lab panel, nutrition plan + ePA — your own data only.",
     keywords: [
       "nutrition",
@@ -97,7 +158,28 @@ export const personalResearchQA: ResearchQA[] = [
       "mediterranean",
       "vitamin d",
     ],
-    trends: [labs.trends[2], nutrition.trends[0]],
+    trends: [
+      {
+        label: "CRP",
+        unit: "mg/l",
+        color: "#7D3C98",
+        current: "0.8",
+        goodDirection: "down",
+        from: NUTR_FROM,
+        to: NUTR_TO,
+        points: gen(NUTR_FROM, NUTR_TO, 1.8, 0.8, 14, [], 1),
+      },
+      {
+        label: "Adherence",
+        unit: "%",
+        color: "#1E8449",
+        current: "86",
+        goodDirection: "up",
+        from: NUTR_FROM,
+        to: NUTR_TO,
+        points: gen(NUTR_FROM, NUTR_TO, 68, 86, 14),
+      },
+    ],
     events: [
       {
         date: "2023-10-02",
@@ -116,7 +198,7 @@ export const personalResearchQA: ResearchQA[] = [
     question:
       "I've been doing daily breathing exercises — any effect on stress and inflammation?",
     answer:
-      "Likely yes — CRP fell from 2.1 to 0.8 mg/L and your HRV improved. Set against your ePA respiratory history — mild asthma, plus a resolved bronchitis (2023) and COVID-19 (2022) — your inflammation is now low, and your seasonal influenza vaccinations are up to date.",
+      "Likely yes — CRP fell to 0.8 mg/L and your HRV improved. The spikes on the graph line up with your ePA infections (COVID-19 in 2022, bronchitis in 2023, flu in 2024); between them, and since the breathing exercises, your inflammation is low. Your seasonal influenza vaccinations are up to date.",
     source: "From your lab panel, fitness band + ePA — your own data only.",
     keywords: [
       "breath",
@@ -143,16 +225,57 @@ export const personalResearchQA: ResearchQA[] = [
       "vaccination",
       "immunization",
     ],
-    trends: [labs.trends[2], fitness.trends[1]],
-    events: [
+    trends: [
       {
-        date: "2024-12-03",
-        label: "Influenza (seasonal) — resolved",
-        type: "Infection",
+        label: "CRP",
+        unit: "mg/l",
+        color: "#7D3C98",
+        current: "0.8",
+        goodDirection: "down",
+        from: BREATH_FROM,
+        to: BREATH_TO,
+        points: gen(
+          BREATH_FROM,
+          BREATH_TO,
+          1.4,
+          0.8,
+          20,
+          [
+            { date: "2022-11-08", mag: 4.5 },
+            { date: "2023-03-20", mag: 3.5 },
+            { date: "2024-12-03", mag: 2.2 },
+          ],
+          1,
+        ),
       },
+      {
+        label: "HRV",
+        unit: "ms",
+        color: "#2471A3",
+        current: "48",
+        goodDirection: "up",
+        from: BREATH_FROM,
+        to: BREATH_TO,
+        points: gen(BREATH_FROM, BREATH_TO, 36, 48, 20, [
+          { date: "2022-11-08", mag: -7 },
+          { date: "2024-12-03", mag: -4 },
+        ]),
+      },
+    ],
+    events: [
       {
         date: "2022-11-08",
         label: "COVID-19, mild — recovered",
+        type: "Infection",
+      },
+      {
+        date: "2023-03-20",
+        label: "Acute bronchitis — resolved",
+        type: "Infection",
+      },
+      {
+        date: "2024-12-03",
+        label: "Influenza (seasonal) — resolved",
         type: "Infection",
       },
       {
@@ -171,8 +294,7 @@ export const personalResearchQA: ResearchQA[] = [
 
 /**
  * Resolve a free-text question to one of the predefined answers by keyword
- * overlap (the static demo has no LLM). Returns the best match, or null when the
- * question is outside the patient's own data.
+ * overlap (the static demo has no LLM). Returns the best match, or null.
  */
 export function matchPersonalResearch(text: string): ResearchQA | null {
   const t = text.toLowerCase();
@@ -190,4 +312,21 @@ export function matchPersonalResearch(text: string): ResearchQA | null {
     }
   }
   return bestHits > 0 ? best : null;
+}
+
+/** Markers for an event list on a series with a date range (for TrendChart). */
+export function eventMarkers(
+  s: TrendSeries,
+  events: EpaEvent[],
+  colorOf: (type: EpaEvent["type"]) => string,
+) {
+  if (!s.from || !s.to) return [];
+  return events
+    .map((e) => ({
+      x: frac(s.from!, s.to!, e.date),
+      color: colorOf(e.type),
+      label: `${e.type}: ${e.label}`,
+    }))
+    .filter((m) => m.x >= -0.02 && m.x <= 1.02)
+    .map((m) => ({ ...m, x: Math.max(0, Math.min(1, m.x)) }));
 }


### PR DESCRIPTION
Per feedback ('show the events in the trends — the graph should reflect the events'): the answer trends now span the patient's **multi-year ePA history** and **reflect the events** — CRP spikes at the COVID/bronchitis/flu infection dates, VO₂max dips at the 2020 knee surgery — with each event **marked on the line** (vertical marker + colored dot, matching the 'Related ePA events' badges). Year-range footer + dynamic span label (e.g. '5y').

Verified on :3000: 10 markers on the breathing CRP/HRV charts, 2021–2026 span, spikes aligned to infection dates. 1754 tests pass, coverage 82.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)