### PR TITLE
feat(patient): nutrition weekly goals — 30 plants/week, fibre & protein

### DIFF
--- a/ui/__tests__/unit/components/health-detail.test.tsx
+++ b/ui/__tests__/unit/components/health-detail.test.tsx
@@ -42,6 +42,31 @@ describe("HealthDetailModal", () => {
     expect(screen.getAllByText(/kcal/i).length).toBeGreaterThanOrEqual(7);
   });
 
+  it("shows weekly goals (30 plants/week, fibre, protein) with progress bars", () => {
+    render(<HealthDetailModal source={nutrition} onClose={() => {}} />);
+    expect(screen.getByText("Weekly goals")).toBeInTheDocument();
+    // 30-plants-per-week goal
+    expect(screen.getByText("/ 30 plants/wk")).toBeInTheDocument();
+    expect(screen.getByText("30 different fruit & veg")).toBeInTheDocument();
+    // fibre + protein appear both as a goal and as an intake trend
+    expect(screen.getAllByText("Fibre").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Protein").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("WHO ≥ 25–30 g/day")).toBeInTheDocument();
+    expect(screen.getByText("≈ 1.2 g/kg body weight")).toBeInTheDocument();
+    // three progress bars, two of which are met (fibre 34≥30, protein 95≥75)
+    expect(screen.getAllByRole("progressbar")).toHaveLength(3);
+    expect(screen.getAllByText("met")).toHaveLength(2);
+    // plants (27/30) shows a text "to go" cue — not colour alone (WCAG 1.4.1)
+    expect(screen.getByText("3 to go")).toBeInTheDocument();
+  });
+
+  it("shows fibre and protein intake as 12-week trends", () => {
+    render(<HealthDetailModal source={nutrition} onClose={() => {}} />);
+    // Plants/Fibre/Protein each render once as a trend label (and once as a goal)
+    expect(screen.getAllByText("Plants").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/g\/day/).length).toBeGreaterThanOrEqual(2);
+  });
+
   it("uses no Whoop trademark in any personal-health source", () => {
     for (const s of personalHealth) {
       expect(s.source).not.toContain("Whoop");

--- a/ui/src/components/HealthDetailModal.tsx
+++ b/ui/src/components/HealthDetailModal.tsx
@@ -8,9 +8,30 @@
  */
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { X, TrendingUp, TrendingDown, CalendarDays } from "lucide-react";
+import {
+  X,
+  TrendingUp,
+  TrendingDown,
+  CalendarDays,
+  Target,
+  Check,
+  Leaf,
+  Wheat,
+  Drumstick,
+} from "lucide-react";
 import { TrendChart } from "@/components/charts/TrendChart";
-import type { PersonalHealthSource, TrendSeries } from "@/lib/journey-config";
+import type {
+  PersonalHealthSource,
+  TrendSeries,
+  WeeklyGoal,
+} from "@/lib/journey-config";
+
+/** Maps a weekly-goal icon key to its lucide glyph. */
+const GOAL_ICON: Record<WeeklyGoal["icon"], typeof Leaf> = {
+  plants: Leaf,
+  fibre: Wheat,
+  protein: Drumstick,
+};
 
 function deltaChip(s: TrendSeries) {
   const first = s.points[0];
@@ -96,6 +117,87 @@ export function HealthDetailModal({
         <p className="text-sm text-[var(--text-secondary)] mb-5">
           {source.detail}
         </p>
+
+        {/* Weekly nutrition goals — plant diversity / fibre / protein */}
+        {source.weeklyGoals && (
+          <div className="mb-5">
+            <p className="flex items-center gap-1.5 text-sm font-bold text-[var(--text-primary)] mb-2">
+              <Target
+                size={15}
+                aria-hidden="true"
+                style={{ color: source.brand }}
+              />
+              Weekly goals
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {source.weeklyGoals.map((g) => {
+                const Icon = GOAL_ICON[g.icon];
+                const met = g.current >= g.target;
+                const ratio = Math.min(1, g.current / g.target);
+                const accent = met ? "#1E8449" : "#CA6F1E";
+                return (
+                  <div
+                    key={g.label}
+                    className="rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="inline-flex items-center gap-1.5 text-xs font-bold text-[var(--text-primary)]">
+                        <Icon
+                          size={14}
+                          aria-hidden="true"
+                          style={{ color: accent }}
+                        />
+                        {g.label}
+                      </span>
+                      {/* Status chip in BOTH states — text cue, not colour alone (WCAG 1.4.1) */}
+                      <span
+                        className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap"
+                        style={{ color: accent, background: `${accent}1a` }}
+                      >
+                        {met ? (
+                          <>
+                            <Check size={10} aria-hidden="true" /> met
+                          </>
+                        ) : (
+                          `${g.target - g.current} to go`
+                        )}
+                      </span>
+                    </div>
+                    <div className="flex items-baseline gap-1">
+                      <span className="text-lg font-black text-[var(--text-primary)] tabular-nums">
+                        {g.current}
+                      </span>
+                      <span className="text-xs text-[var(--text-secondary)]">
+                        / {g.target} {g.unit}
+                      </span>
+                    </div>
+                    <div
+                      role="progressbar"
+                      aria-valuenow={Math.min(g.current, g.target)}
+                      aria-valuemin={0}
+                      aria-valuemax={g.target}
+                      aria-valuetext={`${g.current} of ${g.target} ${g.unit}`}
+                      aria-label={`${g.label}: ${g.current} of ${g.target} ${
+                        g.unit
+                      } — ${
+                        met ? "goal met" : `${g.target - g.current} to go`
+                      }`}
+                      className="h-1.5 rounded-full bg-[var(--border)] mt-2 overflow-hidden"
+                    >
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{ width: `${ratio * 100}%`, background: accent }}
+                      />
+                    </div>
+                    <p className="text-[10px] text-[var(--text-secondary)] mt-1">
+                      {g.note}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {/* 3-month weekly trends */}
         <div className="space-y-4">

--- a/ui/src/lib/journey-config.ts
+++ b/ui/src/lib/journey-config.ts
@@ -115,6 +115,21 @@ export interface NutritionDay {
   focus: string;
 }
 
+/** A weekly nutrition target with this-week progress (e.g. 30 plants/week). */
+export interface WeeklyGoal {
+  label: string;
+  /** this week's running count */
+  current: number;
+  /** the weekly target */
+  target: number;
+  /** unit suffix shown after `current / target` (e.g. "plants/wk", "g/day") */
+  unit: string;
+  /** icon key resolved in the detail modal */
+  icon: "plants" | "fibre" | "protein";
+  /** short guideline rationale */
+  note: string;
+}
+
 /** A personal-health data source displayed on the /patient record. */
 export interface PersonalHealthSource {
   id: "fitness" | "labs" | "nutrition";
@@ -134,6 +149,8 @@ export interface PersonalHealthSource {
   trends: TrendSeries[];
   /** optional weekly plan (nutrition) */
   weeklyPlan?: NutritionDay[];
+  /** optional weekly nutrition goals (plant diversity / fibre / protein) */
+  weeklyGoals?: WeeklyGoal[];
 }
 
 /**
@@ -238,8 +255,33 @@ export const personalHealth: PersonalHealthSource[] = [
       { label: "Fibre", value: "34 g/d" },
       { label: "Adherence", value: "86 %" },
     ],
-    detail: "This week's plan, plus a 3-month adherence trend.",
+    detail:
+      "Weekly goals — 30 plants, fibre and protein — plus this week's plan and 3-month trends.",
     trends: [
+      {
+        label: "Plants",
+        unit: "distinct/wk",
+        color: "#148F77",
+        current: "27",
+        goodDirection: "up",
+        points: [18, 19, 20, 19, 21, 22, 23, 24, 25, 26, 26, 27],
+      },
+      {
+        label: "Fibre",
+        unit: "g/day",
+        color: "#CA6F1E",
+        current: "34",
+        goodDirection: "up",
+        points: [26, 27, 28, 27, 29, 30, 31, 31, 32, 33, 33, 34],
+      },
+      {
+        label: "Protein",
+        unit: "g/day",
+        color: "#2471A3",
+        current: "95",
+        goodDirection: "up",
+        points: [82, 84, 85, 86, 88, 89, 90, 91, 92, 93, 94, 95],
+      },
       {
         label: "Adherence",
         unit: "%",
@@ -247,6 +289,32 @@ export const personalHealth: PersonalHealthSource[] = [
         current: "86",
         goodDirection: "up",
         points: [70, 72, 74, 73, 76, 78, 80, 79, 82, 84, 85, 86],
+      },
+    ],
+    weeklyGoals: [
+      {
+        label: "Plants",
+        current: 27,
+        target: 30,
+        unit: "plants/wk",
+        icon: "plants",
+        note: "30 different fruit & veg",
+      },
+      {
+        label: "Fibre",
+        current: 34,
+        target: 30,
+        unit: "g/day",
+        icon: "fibre",
+        note: "WHO ≥ 25–30 g/day",
+      },
+      {
+        label: "Protein",
+        current: 95,
+        target: 75,
+        unit: "g/day",
+        icon: "protein",
+        note: "≈ 1.2 g/kg body weight",
       },
     ],
     weeklyPlan: [


### PR DESCRIPTION
## What

The patient **Nutrition plan** detail modal now shows a **Weekly goals** section, as requested:

| Goal | This week | Target | Status |
|------|-----------|--------|--------|
| 🌿 Plants (fruit & veg diversity) | 27 | 30 / week | `3 to go` |
| 🌾 Fibre | 34 g/day | ≥ 30 g/day | ✓ met |
| 🍗 Protein | 95 g/day | ≥ 75 g/day | ✓ met |

Each goal has a progress bar; **Plants, Fibre, Protein** each also get a 12-week intake trend alongside Adherence.

## Guidelines shown (validated)
- **30 different plants/week** — gut-diversity target (American Gut / ZOE).
- **Fibre ≥ 25–30 g/day** — WHO/EFSA adult recommendation.
- **Protein ≈ 1.2 g/kg** — active-adult intake.

All data is synthetic; the modal keeps its *"not medical advice"* footer.

## Accessibility
- Status conveyed by **text** (`met` / `N to go`), not colour alone (WCAG 1.4.1).
- `progressbar` role with `aria-valuetext`; `aria-valuenow` clamped to max for met goals; decorative icons `aria-hidden`.

## Verification
- `tsc`, `eslint` clean; full Vitest suite **1756 pass** (3 new modal assertions).
- Live modal screenshot confirmed against a fresh build.
- Adversarial review (4 agents): 0 blockers; medical-accuracy & code-correctness clean; a11y findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)