### PR TITLE
docs(planning): track issue #97 (EDC upgrade) as future item

### DIFF
--- a/docs/planning/future/issue-97-edc-upgrade.md
+++ b/docs/planning/future/issue-97-edc-upgrade.md
@@ -1,0 +1,13 @@
+---
+title: Upgrade Eclipse EDC components to v0.18.0 + pin image versions (issue #97)
+status: future
+owner: ma3u
+updated: 2026-07-15
+adr: ../../ADRs/ADR-005-jad-cfm-source-builds.md
+---
+
+Connector + IdentityHub are two minors behind (v0.16.0 in use per ADR-020;
+upstream v0.18.0, 2026-06-30) and every JAD/CFM image floats on `:latest`.
+Plan: inventory & pin → rebuild from v0.18.0 → TCK/DCP/EHDS suites + live
+Playwright → CI rollout. Risks: management-API path drift, CFM agents built
+against the EDC BOM. Source: issue #97.

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -16,6 +16,7 @@ Groom with `/plan`. Token budget per ADR-026: keep this index small.
 - [issue-11-weekly-demo-reset](future/issue-11-weekly-demo-reset.md) — weekly baseline refresh (ADR-014)
 - [eudi-wallet-cluster](future/eudi-wallet-cluster.md) — issues #22 / #24 / #80, Phase 27
 - [phase-26g-deferred](future/phase-26g-deferred.md) — federation observability leftovers
+- [issue-97-edc-upgrade](future/issue-97-edc-upgrade.md) — EDC v0.18.0 upgrade + image pinning
 
 ## done/
 


### PR DESCRIPTION
Adds the future/ planning item for #97 per the new /plan workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)