### PR TITLE
docs(planning): widen issue-97 item — Metaform tier + OSS baseline

### DIFF
--- a/docs/planning/future/issue-97-edc-upgrade.md
+++ b/docs/planning/future/issue-97-edc-upgrade.md
@@ -1,13 +1,14 @@
 ---
-title: Upgrade Eclipse EDC components to v0.18.0 + pin image versions (issue #97)
+title: "Dependency refresh: EDC v0.18.0, Metaform JAD/CFM, OSS baseline (issue #97)"
 status: future
 owner: ma3u
 updated: 2026-07-15
 adr: ../../ADRs/ADR-005-jad-cfm-source-builds.md
 ---
 
-Connector + IdentityHub are two minors behind (v0.16.0 in use per ADR-020;
-upstream v0.18.0, 2026-06-30) and every JAD/CFM image floats on `:latest`.
-Plan: inventory & pin → rebuild from v0.18.0 → TCK/DCP/EHDS suites + live
-Playwright → CI rollout. Risks: management-API path drift, CFM agents built
-against the EDC BOM. Source: issue #97.
+Three tiers: (1) Eclipse EDC — Connector + IdentityHub two minors behind
+(v0.16.0 per ADR-020; upstream v0.18.0, 2026-06-30); (2) Metaform sources our
+`jad-*`/`cfm-*` images are built from (`jad`, `cfm-edc`, `cfm-fulcrum`) — rebuild
+in lockstep with EDC (BOM coupling); (3) OSS baseline — Postgres 16-vs-17.7
+local/Azure skew, Node 20 past LTS EOL → 22, unpinned Keycloak/Vault/NATS
+`:latest` tags, Neo4j 2025.x LTS spike. Phases A–D in issue #97.


### PR DESCRIPTION
Planning item now mirrors the updated #97 scope (EDC preferred → Metaform lockstep → OSS baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)