### PR TITLE
chore(deps): issue #97 Phase A — pin all image versions + ADR-029

### DIFF
--- a/docker-compose.jad.yml
+++ b/docker-compose.jad.yml
@@ -93,7 +93,7 @@ services:
   # HashiCorp Vault — Secret management (dev mode)
   # ---------------------------------------------------------------------------
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:2.0
     container_name: health-dataspace-vault
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "root"
@@ -120,7 +120,7 @@ services:
   # Keycloak — OAuth2/OIDC identity provider
   # ---------------------------------------------------------------------------
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:26.6.0
     container_name: health-dataspace-keycloak
     command:
       - "start-dev"
@@ -174,7 +174,7 @@ services:
   # NATS — JetStream messaging bus
   # ---------------------------------------------------------------------------
   nats:
-    image: nats:alpine
+    image: nats:2.14.3-alpine
     container_name: health-dataspace-nats
     command: ["-c", "/etc/nats/nats.conf"]
     volumes:
@@ -208,7 +208,7 @@ services:
   # This sidecar re-runs the idempotent bootstrap on every container start.
   # ---------------------------------------------------------------------------
   vault-bootstrap:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:2.0
     container_name: health-dataspace-vault-bootstrap
     environment:
       VAULT_ADDR: "http://vault:8200"
@@ -234,7 +234,9 @@ services:
   # EDC-V Control Plane — DSP protocol + management APIs
   # ---------------------------------------------------------------------------
   controlplane:
-    image: ghcr.io/ma3u/health-dataspace/jad-controlplane:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/jad-controlplane:latest@sha256:2516cbebd4666f87564c825679fc14d3b515d1a5931f5a18bdd1176cfab64826
     container_name: health-dataspace-controlplane
     environment:
       # Base config
@@ -328,7 +330,9 @@ services:
   # Pushes FHIR Bundle JSON to consumer endpoints via Neo4j Query Proxy.
   # ---------------------------------------------------------------------------
   dataplane-fhir:
-    image: ghcr.io/ma3u/health-dataspace/jad-dataplane:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/jad-dataplane:latest@sha256:9af05fab5af8f3993fdb9ba7f856dae51d2f2d6ef7a9d13d5eb7ba81b544a0ec
     container_name: health-dataspace-dataplane-fhir
     environment:
       edc.hostname: "dataplane-fhir"
@@ -393,7 +397,9 @@ services:
   # Consumer pulls query results from provider via Neo4j Query Proxy.
   # ---------------------------------------------------------------------------
   dataplane-omop:
-    image: ghcr.io/ma3u/health-dataspace/jad-dataplane:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/jad-dataplane:latest@sha256:9af05fab5af8f3993fdb9ba7f856dae51d2f2d6ef7a9d13d5eb7ba81b544a0ec
     container_name: health-dataspace-dataplane-omop
     environment:
       edc.hostname: "dataplane-omop"
@@ -462,7 +468,9 @@ services:
     build:
       context: ./services/neo4j-proxy
       dockerfile: Dockerfile
-    image: ghcr.io/ma3u/health-dataspace/neo4j-proxy:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/neo4j-proxy:latest@sha256:e64e5706b7ddc1e4f094ca6ea295d1124e73e50988067cb6d90950591f8fd85f
     container_name: health-dataspace-neo4j-proxy
     environment:
       NODE_ENV: "production"
@@ -505,7 +513,9 @@ services:
   # IdentityHub — DCP v1.0 credential storage & presentation
   # ---------------------------------------------------------------------------
   identityhub:
-    image: ghcr.io/ma3u/health-dataspace/jad-identity-hub:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/jad-identity-hub:latest@sha256:1dd82530c0208254d660c3800db3fa837225edc450b765ff04a4072eb0bce305
     container_name: health-dataspace-identityhub
     env_file:
       - ./jad/identityhub.env
@@ -544,7 +554,9 @@ services:
   # IssuerService — Verifiable Credential issuance (trust anchor)
   # ---------------------------------------------------------------------------
   issuerservice:
-    image: ghcr.io/ma3u/health-dataspace/jad-issuerservice:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/jad-issuerservice:latest@sha256:b42320defd351c0010b8d55592bdebc12d6ee1ad2fa3387a7b85977fce35c5c1
     container_name: health-dataspace-issuerservice
     env_file:
       - ./jad/issuerservice.env
@@ -587,7 +599,9 @@ services:
   # CFM Tenant Manager — Multi-tenant participant lifecycle
   # ---------------------------------------------------------------------------
   tenant-manager:
-    image: ghcr.io/ma3u/health-dataspace/cfm-tmanager:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-tmanager:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-tenant-manager
     volumes:
       - ./jad/tenant-manager-config.yaml:/etc/appname/tm.env:ro
@@ -610,7 +624,9 @@ services:
   # CFM Provision Manager — Automated resource provisioning
   # ---------------------------------------------------------------------------
   provision-manager:
-    image: ghcr.io/ma3u/health-dataspace/cfm-pmanager:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-pmanager:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-provision-manager
     volumes:
       - ./jad/provision-manager-config.yaml:/etc/appname/pm.env:ro
@@ -635,7 +651,9 @@ services:
   # CFM Agents — Background provisioning agents (Keycloak, EDC-V, Registration, Onboarding)
   # ---------------------------------------------------------------------------
   cfm-agents:
-    image: ghcr.io/ma3u/health-dataspace/cfm-kcagent:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-kcagent:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-cfm-keycloak-agent
     volumes:
       - ./jad/keycloak-agent-config.yaml:/etc/appname/kcagent.env:ro
@@ -649,7 +667,9 @@ services:
     restart: unless-stopped
 
   cfm-edcv-agent:
-    image: ghcr.io/ma3u/health-dataspace/cfm-edcvagent:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-edcvagent:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-cfm-edcv-agent
     volumes:
       - ./jad/edcv-agent-config.yaml:/etc/appname/edcvagent.env:ro
@@ -663,7 +683,9 @@ services:
     restart: unless-stopped
 
   cfm-registration-agent:
-    image: ghcr.io/ma3u/health-dataspace/cfm-regagent:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-regagent:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-cfm-registration-agent
     volumes:
       - ./jad/registration-agent-config.yaml:/etc/appname/regagent.env:ro
@@ -679,7 +701,9 @@ services:
     restart: unless-stopped
 
   cfm-onboarding-agent:
-    image: ghcr.io/ma3u/health-dataspace/cfm-obagent:latest
+    # GHCR :latest pinned by digest (built 2026-04-11, EDC 0.16 era — ADR-029);
+    # Phase B of issue #97 replaces this with a versioned rebuild tag.
+    image: ghcr.io/ma3u/health-dataspace/cfm-obagent:latest@sha256:c50cca3ffdf3c8a7657be9f51bdf79a3a09f1ba35458a17fc343c979f280dd54
     container_name: health-dataspace-cfm-onboarding-agent
     volumes:
       - ./jad/onboarding-agent-config.yaml:/etc/appname/obagent.env:ro
@@ -704,7 +728,7 @@ services:
   # Runs once after all services are healthy, then exits.
   # ---------------------------------------------------------------------------
   jad-seed:
-    image: curlimages/curl:latest
+    image: curlimages/curl:8.21.0
     container_name: health-dataspace-jad-seed
     entrypoint: ["/bin/sh", "/scripts/seed-jad.sh"]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   neo4j:
-    image: neo4j:5-community
+    image: neo4j:5.26.28-community
     container_name: health-dataspace-neo4j
     ports:
       - "7474:7474" # Browser UI
@@ -27,7 +27,7 @@ services:
   # for federated query testing (Phase 5). Runs a disjoint patient subset from a
   # different geographic region (e.g., New York vs Massachusetts).
   neo4j-spe2:
-    image: neo4j:5-community
+    image: neo4j:5.26.28-community
     container_name: health-dataspace-neo4j-spe2
     ports:
       - "7475:7474" # Browser UI (offset from primary)

--- a/docs/ADRs/ADR-029-dependency-version-pinning.md
+++ b/docs/ADRs/ADR-029-dependency-version-pinning.md
@@ -1,0 +1,79 @@
+# ADR-029: Dependency version pinning and refresh cadence
+
+**Status:** Accepted
+**Date:** 2026-07-15
+**Relates to:** [ADR-005](ADR-005-jad-cfm-source-builds.md), [ADR-006](ADR-006-ghcr-image-publishing.md), [ADR-012](ADR-012-azure-container-apps.md), [ADR-017](ADR-017-persistent-storage-aca.md)
+**Tracks:** [Issue #97 — dependency refresh](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/97), Phase A
+
+## Context
+
+Before this ADR, every third-party image in `docker-compose*.yml` and
+`scripts/azure/env.sh` floated (`:latest`, `:alpine`, `neo4j:5-community`,
+`postgres:16`), and all 11 self-published `ghcr.io/ma3u/health-dataspace/*`
+images existed only as `:latest`. Combined with ACA's `:latest` caching
+(`docs/gotchas.md`, 2026-04), we could not state which build ran where.
+Compounding it, local and Azure Postgres diverged (17.7 vs 16).
+
+Inventory performed 2026-07-15 (registry manifests + live instances):
+
+| Image                     | Was            | Resolved to               | Evidence                                                                                                                                                                                |
+| ------------------------- | -------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| quay.io/keycloak/keycloak | `:latest`      | **26.6.0** (Java 21.0.10) | live `admin/serverinfo` on auth.ehds.mabu.red                                                                                                                                           |
+| hashicorp/vault           | `:latest`      | **2.0**                   | Docker Hub digest match                                                                                                                                                                 |
+| nats                      | `:alpine`      | **2.14.3-alpine**         | Docker Hub digest match                                                                                                                                                                 |
+| neo4j                     | `:5-community` | **5.26.28-community**     | Docker Hub digest match                                                                                                                                                                 |
+| curlimages/curl           | `:latest`      | **8.21.0**                | Docker Hub digest match                                                                                                                                                                 |
+| postgres (local)          | 17.7-alpine    | already pinned            | compose file                                                                                                                                                                            |
+| postgres (Azure)          | `:16`          | **16.14** pin             | Docker Hub tag list                                                                                                                                                                     |
+| ghcr `jad-*`/`cfm-*` (11) | `:latest`      | digest pins               | GHCR manifests, all built **2026-04-11** (EDC 0.16 era, ADR-005); all six `cfm-*` tags share one image; **no OCI source/revision labels** — source commit unrecoverable from the images |
+
+## Decision
+
+1. **Third-party images are pinned to exact versions** — the version each
+   floating tag resolved to on 2026-07-15 (pin-in-place, no upgrades; upgrades
+   are issue #97 Phases B/C). Azure pins live centrally in
+   `scripts/azure/env.sh` (`*_VERSION` variables) and the mirror scripts pull
+   those pinned tags.
+2. **Self-published JAD/CFM images are pinned by digest**
+   (`:latest@sha256:…`) in `docker-compose.jad.yml` until Phase B rebuilds
+   them with proper version tags and OCI `org.opencontainers.image.revision`
+   / `.source` labels (mandatory from Phase B on).
+3. **Our own CD-managed images (`mvhd-ui`, `mvhd-neo4j-proxy`) stay
+   `:latest`** — they are rebuilt and rolled by `deploy-azure.yml` on every
+   merge to main; their version identity is the git SHA of main.
+4. **Postgres skew is resolved by documentation, not by upgrade:** Azure stays
+   on major **16** (pinned 16.14) because its data directory lives on ACA
+   persistent storage (ADR-017) and a 16→17 major jump requires
+   `pg_upgrade`/dump-restore — a migration runbook is a Phase C deliverable.
+   Local dev (ephemeral, reseedable) stays on 17.x. The skew is intentional
+   and bounded to the major version.
+5. **Refresh cadence:** patch/minor bumps land as deliberate PRs, one service
+   per PR, at most monthly, gated by the standard suites
+   (`run-dsp-tck.sh`, `run-dcp-tests.sh`, `run-ehds-tests.sh`, Vitest,
+   Playwright live). Exceptions: security advisories (immediate) and the
+   `npm audit --audit-level=high` pre-push gate that already exists.
+6. `traefik:v3.4` keeps its bounded minor tag (patch tags for that line are no
+   longer enumerable on Docker Hub; the v3.4 line is EOL-bound and will be
+   bumped in Phase C instead).
+
+## Consequences
+
+- Reproducible stack: every compose/provision run yields the same bits;
+  ACA `:latest` cache staleness can no longer cause silent version drift for
+  third-party services.
+- Version bumps become visible in diffs and reviewable.
+- Digest pins are unreadable — acceptable as a Phase A stopgap; Phase B
+  replaces them with versioned tags + provenance labels.
+- The Metaform source commits behind the 2026-04-11 JAD/CFM builds remain
+  UNKNOWN (no labels, no local `vendor/` checkout) — Phase B must rebuild from
+  known commits rather than recover the old provenance.
+
+## Alternatives considered
+
+- **Renovate/Dependabot for images** — rejected for now: the JAD/CFM images
+  have no version tags to track, and auto-bump PRs without the live-stack
+  suites would create noise; revisit after Phase B tagging.
+- **Upgrade Azure Postgres to 17 now** — rejected: data migration on ACA
+  persistent storage without a tested runbook risks the 24/7 demo (ADR-018).
+- **Digest-pin the third-party images too** — rejected: version tags from
+  official registries are effectively immutable and stay human-readable.

--- a/docs/planning-health-dataspace-v2.md
+++ b/docs/planning-health-dataspace-v2.md
@@ -137,5 +137,6 @@ All three core specifications are now final or near-final:
 | [026](ADRs/ADR-026-token-efficient-planning-structure.md)    | Token-Efficient Planning & ADR Structure       | 2026-05-17 | Accepted   |
 | [027](ADRs/ADR-027-edc-stack-off-hours-scaledown.md)         | EDC Stack in Off-Hours Scale-Down (FinOps)     | 2026-05-18 | Accepted   |
 | [028](ADRs/ADR-028-patient-qr-login-eudi-wallet.md)          | Patient QR Login via EUDI Wallet (OpenID4VP)   | 2026-06-04 | Accepted   |
+| [029](ADRs/ADR-029-dependency-version-pinning.md)            | Dependency Version Pinning & Refresh Cadence   | 2026-07-15 | Accepted   |
 
 > **Note:** The full text of ADR-1 through ADR-9 has been moved into the standalone ADR documents linked in the table above. Click any row to read the full context, decision, and consequences.

--- a/docs/planning/current/issue-97-edc-upgrade.md
+++ b/docs/planning/current/issue-97-edc-upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: "Dependency refresh: EDC v0.18.0, Metaform JAD/CFM, OSS baseline (issue #97)"
-status: future
+status: current
 owner: ma3u
 updated: 2026-07-15
 adr: ../../ADRs/ADR-005-jad-cfm-source-builds.md
@@ -11,4 +11,4 @@ Three tiers: (1) Eclipse EDC — Connector + IdentityHub two minors behind
 `jad-*`/`cfm-*` images are built from (`jad`, `cfm-edc`, `cfm-fulcrum`) — rebuild
 in lockstep with EDC (BOM coupling); (3) OSS baseline — Postgres 16-vs-17.7
 local/Azure skew, Node 20 past LTS EOL → 22, unpinned Keycloak/Vault/NATS
-`:latest` tags, Neo4j 2025.x LTS spike. Phases A–D in issue #97.
+`:latest` tags, Neo4j 2025.x LTS spike. Phases A–D in issue #97. **Phase A done 2026-07-15** (ADR-029): inventory, tag/digest pins in compose + azure env, Postgres skew documented.

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -7,6 +7,7 @@ Groom with `/plan`. Token budget per ADR-026: keep this index small.
 
 ## current/
 
+- [issue-97-edc-upgrade](current/issue-97-edc-upgrade.md) — dependency refresh; Phase A done, next Phase B (EDC v0.18)
 - [issue-20-leitlinien-ingestion](current/issue-20-leitlinien-ingestion.md) — AWMF Leitlinien Layer-6 ingestion (Docling)
 - [issue-19-nlq-researcher](current/issue-19-nlq-researcher.md) — NLQ researcher improvements (pharmacovigilance)
 - [issue-4-bsi-c5-production](current/issue-4-bsi-c5-production.md) — BSI C5 production security track
@@ -16,7 +17,6 @@ Groom with `/plan`. Token budget per ADR-026: keep this index small.
 - [issue-11-weekly-demo-reset](future/issue-11-weekly-demo-reset.md) — weekly baseline refresh (ADR-014)
 - [eudi-wallet-cluster](future/eudi-wallet-cluster.md) — issues #22 / #24 / #80, Phase 27
 - [phase-26g-deferred](future/phase-26g-deferred.md) — federation observability leftovers
-- [issue-97-edc-upgrade](future/issue-97-edc-upgrade.md) — EDC v0.18.0 upgrade + image pinning
 
 ## done/
 

--- a/scripts/azure/02-data-layer.sh
+++ b/scripts/azure/02-data-layer.sh
@@ -19,8 +19,8 @@ ACR_PASSWORD=$(az acr credential show --name "$ACR_NAME" --query "passwords[0].v
 
 # ── Push Postgres image to ACR ──────────────────────────────────────────────
 log "Pulling and pushing postgres:16 image..."
-docker pull --platform linux/amd64 postgres:16
-docker tag postgres:16 "${PG_IMAGE}"
+docker pull --platform linux/amd64 "postgres:${POSTGRES_VERSION}"
+docker tag "postgres:${POSTGRES_VERSION}" "${PG_IMAGE}"
 docker push "${PG_IMAGE}"
 ok "Postgres image in ACR"
 
@@ -79,8 +79,8 @@ ok "Postgres volume attached (pg-data → /var/lib/postgresql/data)"
 
 # ── Push Neo4j image to ACR ─────────────────────────────────────────────────
 log "Pulling and pushing Neo4j image..."
-docker pull --platform linux/amd64 neo4j:5-community
-docker tag neo4j:5-community "${NEO4J_IMAGE}"
+docker pull --platform linux/amd64 "neo4j:${NEO4J_VERSION}"
+docker tag "neo4j:${NEO4J_VERSION}" "${NEO4J_IMAGE}"
 docker push "${NEO4J_IMAGE}"
 ok "Neo4j image in ACR"
 

--- a/scripts/azure/03-identity.sh
+++ b/scripts/azure/03-identity.sh
@@ -14,8 +14,8 @@ PG_JDBC="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${KC_DB_NAME}?sslmode=disable"
 # ── Push Keycloak image ─────────────────────────────────────────────────────
 log "Pulling and pushing Keycloak image..."
 az acr login --name "$ACR_NAME"
-docker pull --platform linux/amd64 quay.io/keycloak/keycloak:latest
-docker tag quay.io/keycloak/keycloak:latest "${KEYCLOAK_IMAGE}"
+docker pull --platform linux/amd64 "quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}"
+docker tag "quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}" "${KEYCLOAK_IMAGE}"
 docker push "${KEYCLOAK_IMAGE}"
 ok "Keycloak image in ACR"
 
@@ -45,8 +45,8 @@ ok "Keycloak container app ${KEYCLOAK_APP}"
 
 # ── Push Vault image ────────────────────────────────────────────────────────
 log "Pulling and pushing Vault image..."
-docker pull --platform linux/amd64 hashicorp/vault:latest
-docker tag hashicorp/vault:latest "${VAULT_IMAGE}"
+docker pull --platform linux/amd64 "hashicorp/vault:${VAULT_VERSION}"
+docker tag "hashicorp/vault:${VAULT_VERSION}" "${VAULT_IMAGE}"
 docker push "${VAULT_IMAGE}"
 ok "Vault image in ACR"
 

--- a/scripts/azure/04-edc-services.sh
+++ b/scripts/azure/04-edc-services.sh
@@ -13,8 +13,8 @@ ACR_PASSWORD=$(az acr credential show --name "$ACR_NAME" --query "passwords[0].v
 
 # ── Push NATS image ─────────────────────────────────────────────────────────
 log "Pulling and pushing NATS image..."
-docker pull --platform linux/amd64 nats:alpine
-docker tag nats:alpine "${NATS_IMAGE}"
+docker pull --platform linux/amd64 "nats:${NATS_VERSION}"
+docker tag "nats:${NATS_VERSION}" "${NATS_IMAGE}"
 docker push "${NATS_IMAGE}"
 ok "NATS image in ACR"
 

--- a/scripts/azure/env.sh
+++ b/scripts/azure/env.sh
@@ -40,7 +40,10 @@ export PG_HOST="$PG_APP"
 export PG_PORT=5432
 export PG_ADMIN="mvhdadmin"
 export PG_PASSWORD="H3althDataSp@ce2026!"
-export PG_IMAGE="${ACR_NAME}.azurecr.io/postgres:16"
+# Pinned per ADR-029 (issue #97 Phase A): major 16 on Azure until a
+# pg_upgrade/dump-restore migration exists — local dev runs 17.x.
+export POSTGRES_VERSION="16.14"
+export PG_IMAGE="${ACR_NAME}.azurecr.io/postgres:${POSTGRES_VERSION}"
 export PG_DATABASES=(keycloak controlplane dataplane dataplane_omop identityhub issuerservice cfm)
 
 # ── Custom domain (24/7 public demo) ────────────────────────────────────────
@@ -68,14 +71,25 @@ export FHIR_LOADER_JOB="mvhd-fhir-loader"
 export CATALOG_CRAWLER_JOB="mvhd-catalog-crawler"
 export CATALOG_ENRICHER_APP="mvhd-catalog-enricher"
 
+# ── Pinned upstream versions (ADR-029; issue #97 Phase A, inventoried 2026-07-15)
+# Third-party images are pinned to what the floating tags resolved to at pin
+# time (Docker Hub/Quay digests verified). Bumps are deliberate PRs, not pulls.
+# POSTGRES_VERSION is pinned above next to PG_IMAGE.
+export NEO4J_VERSION="5.26.28-community"
+export KEYCLOAK_VERSION="26.6.0" # matches live auth.ehds.mabu.red (verified 2026-07-15)
+export VAULT_VERSION="2.0"
+export NATS_VERSION="2.14.3-alpine"
+
 # ── Container images ─────────────────────────────────────────────────────────
 export ACR_LOGIN_SERVER="${ACR_NAME}.azurecr.io"
+# mvhd-ui / mvhd-neo4j-proxy stay :latest on purpose — they are OUR images,
+# rebuilt and rolled by deploy-azure.yml on every merge to main (ADR-029).
 export UI_IMAGE="${ACR_LOGIN_SERVER}/mvhd-ui:latest"
 export NEO4J_PROXY_IMAGE="${ACR_LOGIN_SERVER}/mvhd-neo4j-proxy:latest"
-export NEO4J_IMAGE="${ACR_LOGIN_SERVER}/neo4j:5-community"
-export KEYCLOAK_IMAGE="${ACR_LOGIN_SERVER}/keycloak:latest"
-export VAULT_IMAGE="${ACR_LOGIN_SERVER}/vault:latest"
-export NATS_IMAGE="${ACR_LOGIN_SERVER}/nats:alpine"
+export NEO4J_IMAGE="${ACR_LOGIN_SERVER}/neo4j:${NEO4J_VERSION}"
+export KEYCLOAK_IMAGE="${ACR_LOGIN_SERVER}/keycloak:${KEYCLOAK_VERSION}"
+export VAULT_IMAGE="${ACR_LOGIN_SERVER}/vault:${VAULT_VERSION}"
+export NATS_IMAGE="${ACR_LOGIN_SERVER}/nats:${NATS_VERSION}"
 export CONTROLPLANE_IMAGE="${ACR_LOGIN_SERVER}/jad-controlplane:latest"
 export DP_FHIR_IMAGE="${ACR_LOGIN_SERVER}/jad-dataplane:latest"
 export DP_OMOP_IMAGE="${ACR_LOGIN_SERVER}/jad-dataplane:latest"


### PR DESCRIPTION
## Summary (Phase A of #97 — inventory & pin, no upgrades)

**Inventory (2026-07-15):**
- All 11 `ghcr.io/ma3u/health-dataspace/*` JAD/CFM images built **2026-04-11**, no OCI provenance labels, all six `cfm-*` tags share one digest → source commits unrecoverable (Phase B rebuilds from known commits, labels become mandatory)
- Live Keycloak = **26.6.0** (Java 21.0.10, verified via admin serverinfo); `vault:latest`→2.0, `nats:alpine`→2.14.3, `neo4j:5-community`→5.26.28, `curl:latest`→8.21.0 (Docker Hub digest matches)

**Pins:**
- `docker-compose.jad.yml`: third-party tags pinned; JAD/CFM/neo4j-proxy pinned by digest with Phase-B comment
- `docker-compose.yml`: neo4j 5.26.28-community
- `scripts/azure/env.sh`: central `*_VERSION` pins consumed by mirror scripts 02/03/04; `mvhd-ui`/`mvhd-neo4j-proxy` stay `:latest` by design (CD-managed)
- **Postgres skew resolved by decision** (ADR-029 §4): Azure pins 16.14 on major 16 until a pg_upgrade runbook exists (ACA persistent storage); local stays 17.x

**ADR-029** (Accepted): inventory table, pinning policy, monthly one-service-per-PR refresh cadence. Linked in planning index; planning item promoted to current/.

## Verification
- [x] `docker compose config -q` valid for both compose files
- [x] shellcheck (error) clean on all touched azure scripts
- [x] Pre-commit + pre-push gates green

## Notes / limits
- ACR re-mirror + ACA rollout of the pinned tags happens at next provisioning run or via CI — az CLI session on this machine expired (re-login needed for live verification)
- Closes the first three Phase A checkboxes of #97; the ADR checkbox is this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)