### PR TITLE
chore(keycloak): 26.6.0 → 26.6.4 patch bump (issue #97 Phase C)

### DIFF
--- a/docker-compose.jad.yml
+++ b/docker-compose.jad.yml
@@ -120,7 +120,7 @@ services:
   # Keycloak — OAuth2/OIDC identity provider
   # ---------------------------------------------------------------------------
   keycloak:
-    image: quay.io/keycloak/keycloak:26.6.0
+    image: quay.io/keycloak/keycloak:26.6.4
     container_name: health-dataspace-keycloak
     command:
       - "start-dev"

--- a/scripts/azure/env.sh
+++ b/scripts/azure/env.sh
@@ -76,7 +76,7 @@ export CATALOG_ENRICHER_APP="mvhd-catalog-enricher"
 # time (Docker Hub/Quay digests verified). Bumps are deliberate PRs, not pulls.
 # POSTGRES_VERSION is pinned above next to PG_IMAGE.
 export NEO4J_VERSION="5.26.28-community"
-export KEYCLOAK_VERSION="26.6.0" # matches live auth.ehds.mabu.red (verified 2026-07-15)
+export KEYCLOAK_VERSION="26.6.4" # patch bump from live 26.6.0 (Phase C, ADR-029 cadence)
 export VAULT_VERSION="2.0"
 export NATS_VERSION="2.14.3-alpine"
 


### PR DESCRIPTION
One-service-per-PR cadence per ADR-029. Same 26.6 minor as live; compose + azure env pins. Realm regression tests (keycloak-realm.test.ts) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)