### PR TITLE
docs(deps): issue #97 Phase C wrap — Postgres runbook + Neo4j 2025.x spike (ADR-030)

### DIFF
--- a/docs/ADRs/ADR-030-neo4j-2025-lts-migration.md
+++ b/docs/ADRs/ADR-030-neo4j-2025-lts-migration.md
@@ -1,0 +1,50 @@
+# ADR-030: Neo4j 5.26 → 2025.x calver line — migration readiness
+
+**Status:** Proposed
+**Date:** 2026-07-16
+**Relates to:** [ADR-019](ADR-019-gds-apoc-azure-ai-foundry-graphrag.md), [ADR-029](ADR-029-dependency-version-pinning.md)
+**Tracks:** [Issue #97 — dependency refresh](https://github.com/ma3u/MinimumViableHealthDataspacev2/issues/97), Phase C spike
+
+## Context
+
+We pin `neo4j:5.26.28-community` (ADR-029) — the last 5.x line. Neo4j moved to
+calver; the 2025.x line ends at 2025.12.1 and 2026.06 is current. Before any
+migration decision we spiked our actual workload against `2025.12.1-community`
+(2026-07-16, throwaway Docker container).
+
+## Spike results (all against neo4j:2025.12.1-community)
+
+| Check                                                    | Result                                                            |
+| -------------------------------------------------------- | ----------------------------------------------------------------- |
+| Full `neo4j/init-schema.cypher` apply                    | ✅ 0 errors                                                       |
+| Idempotent re-run of the schema                          | ✅ 0 errors                                                       |
+| `insert-synthetic-schema-data.cypher` seed               | ✅ 0 errors (124 nodes)                                           |
+| Vector indexes (3 from schema + 1 ad-hoc 768-dim cosine) | ✅ created + `db.index.vector.queryNodes` returns correct results |
+| Constraints                                              | ✅ 39 present                                                     |
+| APOC plugin                                              | ✅ loads, reports 2025.12.1                                       |
+
+**Not covered by the spike:** GDS (`gds.graph.project.cypher` — see the
+2026-04 gotchas), the Azure AI Foundry embedding registration path
+(`register-embeddings-aoai.cypher` at production scale), and the proxy's
+GraphRAG tier against a full 127-patient graph.
+
+## Decision (proposed)
+
+Migrate to the newest calver LTS-designated release **in Phase D or later**,
+gated on one full-stack rehearsal: JAD stack + GDS-dependent GraphRAG suite
+(`33-graphrag-nlp.spec.ts`) against a calver Neo4j with production-shaped
+data. Until then 5.26.x remains the pin — it is still a supported LTS line
+and nothing in the current workload requires calver features.
+
+## Consequences
+
+- No forced migration now; the upgrade is de-risked and scheduled, not ad hoc.
+- The spike script lives in this ADR's table; re-running it against 2026.06
+  when scheduling Phase D costs minutes.
+
+## Alternatives considered
+
+- **Migrate now** — rejected: GDS/GraphRAG path unverified, and 5.26.x is
+  still in support; no feature pressure.
+- **Never migrate / ride 5.26 to EOL** — rejected: 5.x support ends before
+  the project's horizon; calver is where vector/GDS improvements land.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -34,7 +34,8 @@ content — gaps are marked `UNKNOWN`.
 [jad-stack-seeding](runbooks/jad-stack-seeding.md) ·
 [azure-deploy](runbooks/azure-deploy.md) ·
 [keycloak-realm-drift](runbooks/keycloak-realm-drift.md) ·
-[federated-discovery](runbooks/federated-discovery.md)
+[federated-discovery](runbooks/federated-discovery.md) ·
+[postgres-16-to-17-azure](runbooks/postgres-16-to-17-azure.md)
 
 ## decisions/
 

--- a/docs/knowledge/runbooks/postgres-16-to-17-azure.md
+++ b/docs/knowledge/runbooks/postgres-16-to-17-azure.md
@@ -1,0 +1,51 @@
+---
+type: runbook
+title: Postgres 16 → 17 major upgrade on Azure (mvhd-postgres)
+description: Dump/restore migration for the ACA Postgres with persistent storage — closes the local/Azure major-version skew from ADR-029 §4.
+resource: scripts/azure/02-data-layer.sh, ADR-017 (persistent storage), ADR-029 §4
+tags: [runbook, postgres, azure, migration, issue-97]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Azure runs `postgres:16.14` (pinned, ADR-029) with its data directory on ACA
+persistent storage (ADR-017); local dev runs 17.x. A major bump cannot be done
+by changing the image tag — PG 17 refuses to start on a 16 data directory.
+Dump/restore is the ACA-compatible path (no shell access for `pg_upgrade`
+across versions).
+
+## Preconditions
+
+- Maintenance window (the 7 databases serve controlplane, dataplanes,
+  identityhub, issuerservice, keycloak, cfm — the whole EDC stack pauses).
+- `az login` with write permissions (or run via CI-SP — ACA-write gotcha in
+  `docs/gotchas.md`).
+- Free storage ≥ 2× current data size on the ACA file share.
+
+## Procedure
+
+1. **Scale writers to zero** (order: UI-facing first):
+   `az containerapp update -n <app> -g rg-mvhd-dev --min-replicas 0 --max-replicas 0`
+   for controlplane, dp-fhir, dp-omop, identityhub, issuerservice,
+   tenant-mgr, provision-mgr, keycloak.
+2. **Dump all databases** inside the running PG 16 container:
+   `az containerapp exec -n mvhd-postgres -g rg-mvhd-dev --command "pg_dumpall -U mvhdadmin -f /var/lib/postgresql/data/all-pg16.sql"`
+   (the dump lands on the persistent share and survives the container swap).
+3. **Verify dump size** > 0 and contains all 7 DB names before proceeding.
+4. **Point the data dir at a fresh path:** update the app's `PGDATA` env (or
+   mount subpath) to a new directory, e.g. `/var/lib/postgresql/data/pg17`,
+   so the 16 datadir stays untouched as rollback.
+5. **Swap the image:** mirror `postgres:17.10-alpine` to ACR
+   (`scripts/azure/02-data-layer.sh` pattern), update `POSTGRES_VERSION` in
+   `scripts/azure/env.sh`, `az containerapp update` mvhd-postgres.
+6. **Restore:** `az containerapp exec … "psql -U mvhdadmin -f /var/lib/postgresql/data/all-pg16.sql postgres"`.
+7. **Verify:** the `PG_DATABASES` list from `env.sh` exists; row counts on
+   `controlplane` contract tables match the pre-dump counts.
+8. **Scale services back up**; run `./scripts/run-dsp-tck.sh` and a login
+   smoke test against https://ehds.mabu.red.
+9. **Rollback path:** revert image to 16.14 + `PGDATA` to the old directory —
+   the 16 datadir was never modified.
+10. After 7 quiet days: delete `all-pg16.sql` and the old datadir; flip local
+    compose to the same 17.x patch so the skew stays closed.
+
+`UNKNOWN — exact PGDATA/mount layout of mvhd-postgres; read it with
+"az containerapp show -n mvhd-postgres" before step 4 (az session required).`

--- a/docs/planning-health-dataspace-v2.md
+++ b/docs/planning-health-dataspace-v2.md
@@ -138,5 +138,6 @@ All three core specifications are now final or near-final:
 | [027](ADRs/ADR-027-edc-stack-off-hours-scaledown.md)         | EDC Stack in Off-Hours Scale-Down (FinOps)     | 2026-05-18 | Accepted   |
 | [028](ADRs/ADR-028-patient-qr-login-eudi-wallet.md)          | Patient QR Login via EUDI Wallet (OpenID4VP)   | 2026-06-04 | Accepted   |
 | [029](ADRs/ADR-029-dependency-version-pinning.md)            | Dependency Version Pinning & Refresh Cadence   | 2026-07-15 | Accepted   |
+| [030](ADRs/ADR-030-neo4j-2025-lts-migration.md)              | Neo4j 5.26 → 2025.x Migration Readiness        | 2026-07-16 | Proposed   |
 
 > **Note:** The full text of ADR-1 through ADR-9 has been moved into the standalone ADR documents linked in the table above. Click any row to read the full context, decision, and consequences.


### PR DESCRIPTION
Phase C closing artifacts:
- **Postgres 16→17 runbook** for the Azure ACA instance (dump/restore, rollback path, verification) — the ADR-029 §4 deliverable
- **ADR-030 (Proposed):** Neo4j 2025.12.1-community spike results — schema/seed/vector-index/APOC all green; migration gated on a GDS/GraphRAG rehearsal
- Node 22 (#103) and Keycloak 26.6.4 (#104) already merged separately per the one-service-per-PR cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)