### PR TITLE
docs(runbook): ACA Postgres is ephemeral — incident recovery runbook

### DIFF
--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -35,7 +35,8 @@ content — gaps are marked `UNKNOWN`.
 [azure-deploy](runbooks/azure-deploy.md) ·
 [keycloak-realm-drift](runbooks/keycloak-realm-drift.md) ·
 [federated-discovery](runbooks/federated-discovery.md) ·
-[postgres-16-to-17-azure](runbooks/postgres-16-to-17-azure.md)
+[postgres-16-to-17-azure](runbooks/postgres-16-to-17-azure.md) ·
+[aca-postgres-ephemeral-recovery](runbooks/aca-postgres-ephemeral-recovery.md)
 
 ## decisions/
 

--- a/docs/knowledge/runbooks/aca-postgres-ephemeral-recovery.md
+++ b/docs/knowledge/runbooks/aca-postgres-ephemeral-recovery.md
@@ -1,0 +1,48 @@
+---
+type: runbook
+title: mvhd-postgres restart/loss recovery (Azure)
+description: Recover the full stack after the ephemeral ACA Postgres restarts or its revision is replaced — verified live during the 2026-07-16 incident.
+resource: incident 2026-07-16 (issue #97 rollout), .github/workflows/reset-demo.yml, jad/keycloak-realm.json
+tags: [runbook, postgres, azure, incident, recovery]
+timestamp: 2026-07-17T00:00:00Z
+---
+
+**Why this exists:** `mvhd-postgres` on ACA is effectively **ephemeral**. Its
+app template contains an Azure Files mount, but `initdb` cannot `chmod` on
+Azure Files, so every revision created _with_ the mount fails; the revision
+that serves traffic runs _without_ mounts. Consequence: **any** update/restart
+of the app replaces the replica and wipes all 7 databases (keycloak,
+controlplane, dataplane, dataplane_omop, identityhub, issuerservice, cfm).
+Confirmed live 2026-07-16 when the ADR-029 tag pin was applied.
+
+## Recovery procedure (verified 2026-07-16/17)
+
+1. **Get a bootable revision:** if the current template has the Azure Files
+   volume, strip it (export `az containerapp show -o yaml`, set
+   `template.volumes`/`volumeMounts` to null, `az containerapp update --yaml`).
+   The new revision initdbs a fresh ephemeral cluster.
+2. **Recreate databases:** `az containerapp job start -n mvhd-pg-init -g rg-mvhd-dev`
+   (job exists for exactly this; verify `Succeeded` in execution list).
+3. **Keycloak:** restart the active revision (schema migrates into the empty
+   `keycloak` DB, admin user re-bootstraps from env), then import the realm —
+   `POST /admin/realms` with `jad/keycloak-realm.json` returns **201** on a
+   fresh instance and includes all users/roles/redirect URIs (this is why the
+   realm file must stay complete — see keycloak-realm-drift runbook).
+   Verify: password grant for all 7 personas.
+4. **EDC/CFM state + Vault:** trigger the demo reset workflow —
+   `gh workflow run reset-demo.yml` — it runs under the CI service principal
+   (no PIM needed), restarts the EDC apps (schema autocreate), re-runs Vault
+   bootstrap, and re-seeds participants/assets/credentials (ADR-014).
+5. **Verify:** all 7 persona logins · `https://ehds.mabu.red/api/health` ·
+   `/data/discover` shows datasets · reset workflow smoke-test job green.
+
+## Notes
+
+- Neo4j is a separate app and unaffected — clinical/graph demo pages keep
+  working throughout; only auth + EDC state go down.
+- `az containerapp exec` needs a TTY; from automation prefer ACA jobs
+  (mvhd-pg-init) over exec.
+- PIM az sessions cap at 4h — long recoveries should lean on CI-SP workflows.
+- Permanent fix options (Phase D): NFS-backed ACA storage or Azure Database
+  for PostgreSQL Flexible Server; until then treat every mvhd-postgres
+  restart as a reset event.

--- a/docs/knowledge/runbooks/postgres-16-to-17-azure.md
+++ b/docs/knowledge/runbooks/postgres-16-to-17-azure.md
@@ -7,11 +7,20 @@ tags: [runbook, postgres, azure, migration, issue-97]
 timestamp: 2026-07-15T00:00:00Z
 ---
 
-Azure runs `postgres:16.14` (pinned, ADR-029) with its data directory on ACA
-persistent storage (ADR-017); local dev runs 17.x. A major bump cannot be done
-by changing the image tag — PG 17 refuses to start on a 16 data directory.
-Dump/restore is the ACA-compatible path (no shell access for `pg_upgrade`
-across versions).
+> **⚠️ CORRECTED after the 2026-07-16 incident** (see
+> [aca-postgres-ephemeral-recovery](aca-postgres-ephemeral-recovery.md)):
+> `mvhd-postgres` data is **EPHEMERAL** — the app template carries an Azure
+> Files mount, but Postgres `initdb` cannot `chmod` on Azure Files, so every
+> revision created with that mount **fails to boot**; the long-running
+> revision that actually served traffic had **no volume mounts**. Any restart
+> or image change loses all data and requires the re-seed procedure. The
+> steps below that assume a persistent share (dump-to-share, PGDATA swap,
+> rollback-to-old-datadir) are therefore INVALID until persistent storage is
+> actually fixed (NFS-backed share or managed PostgreSQL — Phase D decision).
+
+Azure runs `postgres:16` with local dev on 17.x. A major bump cannot be done
+by changing the image tag — and on the current ephemeral setup ANY image
+change is a full data reset (recovery runbook above).
 
 ## Preconditions
 


### PR DESCRIPTION
Records the 2026-07-16 finding + verified recovery: mvhd-postgres data is ephemeral (the Azure Files mount can never boot — initdb chmod), so any restart is a reset event. Corrects the 16→17 migration runbook; permanent fix (NFS share or managed Postgres) goes to Phase D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)